### PR TITLE
Feature/0003 category model system seed

### DIFF
--- a/app/src/main/java/com/moneymind/finance/di/DI.java
+++ b/app/src/main/java/com/moneymind/finance/di/DI.java
@@ -2,7 +2,9 @@ package com.moneymind.finance.di;
 
 import com.moneymind.classifier.ports.Classifier;
 import com.moneymind.finance.domain.banks.ListBanks;
+import com.moneymind.finance.domain.categories.ListCategories;
 import com.moneymind.finance.domain.ports.BankRegistry;
+import com.moneymind.finance.domain.ports.CategoryRepository;
 import com.moneymind.finance.domain.ports.TransactionClassifier;
 import com.moneymind.finance.domain.ports.TransactionRepository;
 import com.moneymind.finance.domain.ports.TransactionsParser;
@@ -12,6 +14,7 @@ import com.moneymind.finance.domain.transactions.ImportTransactions;
 import com.moneymind.finance.domain.transactions.SearchTransactions;
 import com.moneymind.finance.domain.transactions.UpdateTransactions;
 import com.moneymind.finance.infrastructure.file.TransactionsParserFactory;
+import com.moneymind.finance.infrastructure.postgres.CategoryStore;
 import com.moneymind.finance.infrastructure.postgres.TransactionStore;
 import com.moneymind.finance.infrastructure.txClassifier.ClassificationEngine;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -34,6 +37,18 @@ public class DI {
     @Produces
     TransactionRepository transactionRepository(final DSLContext dataSource) {
         return new TransactionStore(dataSource);
+    }
+
+    @ApplicationScoped
+    @Produces
+    CategoryRepository categoryRepository(final DSLContext dataSource) {
+        return new CategoryStore(dataSource);
+    }
+
+    @ApplicationScoped
+    @Produces
+    ListCategories listCategories(final CategoryRepository categoryRepository) {
+        return new ListCategories(categoryRepository);
     }
 
     @ApplicationScoped

--- a/app/src/main/java/com/moneymind/finance/domain/categories/ListCategories.java
+++ b/app/src/main/java/com/moneymind/finance/domain/categories/ListCategories.java
@@ -1,0 +1,20 @@
+package com.moneymind.finance.domain.categories;
+
+import com.moneymind.finance.domain.core.Category;
+import com.moneymind.finance.domain.ports.CategoryRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public class ListCategories {
+
+    private final CategoryRepository categoryRepository;
+
+    public ListCategories(final CategoryRepository categoryRepository) {
+        this.categoryRepository = categoryRepository;
+    }
+
+    public List<Category> execute(final UUID userId) {
+        return categoryRepository.findCategories(userId);
+    }
+}

--- a/app/src/main/java/com/moneymind/finance/domain/core/Category.java
+++ b/app/src/main/java/com/moneymind/finance/domain/core/Category.java
@@ -1,9 +1,8 @@
 package com.moneymind.finance.domain.core;
 
-/**
- * TODO: Create Category Table per User -> Users should be able to create categories ?
- * TODO: Should supporto only a closed set of categories? Maybe provide both System categories and user categories.
- */
-public enum Category {
-    UNCATEGORIZED
+import java.util.List;
+import java.util.UUID;
+
+public record Category(UUID id, String name, CategoryType type, List<Category> subcategories) {
+    public static final String UNCATEGORIZED = "UNCATEGORIZED";
 }

--- a/app/src/main/java/com/moneymind/finance/domain/core/FinancialRecord.java
+++ b/app/src/main/java/com/moneymind/finance/domain/core/FinancialRecord.java
@@ -28,7 +28,7 @@ public class FinancialRecord {
         this.description = description;
         this.amount = amount;
         this.finalBalance = finalBalance;
-        this.category = String.valueOf(Category.UNCATEGORIZED);  // default
+        this.category = Category.UNCATEGORIZED;
     }
 
     public FinancialRecord(String category, BigDecimal amount) {

--- a/app/src/main/java/com/moneymind/finance/domain/ports/CategoryRepository.java
+++ b/app/src/main/java/com/moneymind/finance/domain/ports/CategoryRepository.java
@@ -1,0 +1,10 @@
+package com.moneymind.finance.domain.ports;
+
+import com.moneymind.finance.domain.core.Category;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface CategoryRepository {
+    List<Category> findCategories(UUID userId);
+}

--- a/app/src/main/java/com/moneymind/finance/infrastructure/postgres/CategoryStore.java
+++ b/app/src/main/java/com/moneymind/finance/infrastructure/postgres/CategoryStore.java
@@ -1,0 +1,60 @@
+package com.moneymind.finance.infrastructure.postgres;
+
+import com.moneymind.finance.domain.core.Category;
+import com.moneymind.finance.domain.core.CategoryType;
+import com.moneymind.finance.domain.ports.CategoryRepository;
+import org.jooq.DSLContext;
+import org.jooq.generated.tables.records.CategoryRecord;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.jooq.generated.tables.Category.CATEGORY;
+
+public class CategoryStore implements CategoryRepository {
+
+    private final DSLContext dsl;
+
+    public CategoryStore(final DSLContext dsl) {
+        this.dsl = dsl;
+    }
+
+    @Override
+    public List<Category> findCategories(final UUID userId) {
+        var rows = dsl
+                .selectFrom(CATEGORY)
+                .where(CATEGORY.USER_ID.isNull()
+                        .or(userId != null ? CATEGORY.USER_ID.eq(userId) : org.jooq.impl.DSL.falseCondition()))
+                .orderBy(CATEGORY.PARENT_ID.asc().nullsFirst(), CATEGORY.ID.asc())
+                .fetchInto(CategoryRecord.class);
+
+        Map<Integer, UUID> uuidById = new LinkedHashMap<>();
+        Map<Integer, String> nameById = new LinkedHashMap<>();
+        Map<Integer, CategoryType> typeById = new LinkedHashMap<>();
+        Map<Integer, List<Category>> childrenByParent = new LinkedHashMap<>();
+        List<Integer> topLevelIds = new ArrayList<>();
+
+        for (CategoryRecord row : rows) {
+            uuidById.put(row.getId(), row.getUuid());
+            nameById.put(row.getId(), row.getName());
+            typeById.put(row.getId(), CategoryType.valueOf(row.getType()));
+
+            if (row.getParentId() == null) {
+                topLevelIds.add(row.getId());
+            } else {
+                childrenByParent.computeIfAbsent(row.getParentId(), k -> new ArrayList<>())
+                        .add(new Category(row.getUuid(), row.getName(), CategoryType.valueOf(row.getType()), List.of()));
+            }
+        }
+
+        List<Category> result = new ArrayList<>();
+        for (Integer id : topLevelIds) {
+            List<Category> subs = childrenByParent.getOrDefault(id, List.of());
+            result.add(new Category(uuidById.get(id), nameById.get(id), typeById.get(id), subs));
+        }
+        return result;
+    }
+}

--- a/app/src/main/java/com/moneymind/finance/infrastructure/txClassifier/ClassificationEngine.java
+++ b/app/src/main/java/com/moneymind/finance/infrastructure/txClassifier/ClassificationEngine.java
@@ -83,6 +83,10 @@ public class ClassificationEngine implements TransactionClassifier {
     }
 
     private Transaction mapToTransaction(final FinancialRecord financialRecord) {
-        return new Transaction(financialRecord.getDescription(), financialRecord.getCategory(), financialRecord.getAmount());
+        return new Transaction(
+                financialRecord.getDescription(),
+                financialRecord.getCategory(),
+                financialRecord.getAmount(),
+                financialRecord.getDate() == null ? null : financialRecord.getDate().toLocalDate());
     }
 }

--- a/app/src/main/java/com/moneymind/finance/infrastructure/web/http/CategoriesResource.java
+++ b/app/src/main/java/com/moneymind/finance/infrastructure/web/http/CategoriesResource.java
@@ -1,25 +1,22 @@
 package com.moneymind.finance.infrastructure.web.http;
 
+import com.moneymind.finance.domain.categories.ListCategories;
+import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
-import java.util.List;
-
 @Path("/categories")
 public class CategoriesResource {
+
+    @Inject
+    ListCategories listCategories;
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public Response list() {
-        return Response.ok(List.of(
-                "HOUSING", "RESTAURANTS", "GROCERIES", "TRAVEL", "FLIGHTS", "ACCOMMODATION",
-                "INCOME", "OTHERS", "NICO", "HEALTH & WELLNESS", "GYM", "PSYCHOLOGY", "SUBSCRIPTIONS",
-                "NETFLIX", "PRIME", "APPLE", "NESPRESSO", "UTILITIES", "WATER", "ELECTRICITY",
-                "APPLIANCES", "SALARY", "FUN MONEY", "INTERNET", "MOBILE", "TRANSFER BETWEEN ACCOUNTS",
-                "FINANCIAL EXPENSES", "CAR", "GASOLINE", "CAR TOOL"
-        )).build();
+        return Response.ok(listCategories.execute(null)).build();
     }
 }

--- a/app/src/main/resources/db/migration/V1.1.0__CreateCategoryTable.sql
+++ b/app/src/main/resources/db/migration/V1.1.0__CreateCategoryTable.sql
@@ -1,0 +1,94 @@
+CREATE TABLE category (
+    id SERIAL PRIMARY KEY,
+    uuid UUID DEFAULT uuid_generate_v4() UNIQUE NOT NULL,
+    user_id UUID NULL,
+    parent_id INTEGER NULL REFERENCES category(id),
+    name VARCHAR(100) NOT NULL,
+    type VARCHAR(20) NOT NULL CHECK (type IN ('INCOME', 'EXPENSE', 'EXCLUDED'))
+);
+
+CREATE INDEX idx_category_uuid ON category(uuid);
+CREATE INDEX idx_category_parent_id ON category(parent_id);
+CREATE INDEX idx_category_user_id ON category(user_id);
+
+-- System Categories: user_id NULL means global / not user-scoped
+-- parent_id NULL means top-level Category; otherwise Subcategory
+
+INSERT INTO category (name, type, user_id, parent_id) VALUES
+    ('HOUSING',               'EXPENSE',  NULL, NULL),
+    ('FOOD & DINING',         'EXPENSE',  NULL, NULL),
+    ('TRANSPORT',             'EXPENSE',  NULL, NULL),
+    ('HEALTH',                'EXPENSE',  NULL, NULL),
+    ('SUBSCRIPTIONS',         'EXPENSE',  NULL, NULL),
+    ('TRAVEL',                'EXPENSE',  NULL, NULL),
+    ('ENTERTAINMENT',         'EXPENSE',  NULL, NULL),
+    ('MISCELLANEOUS',         'EXPENSE',  NULL, NULL),
+    ('INCOME',                'INCOME',   NULL, NULL),
+    ('SAVINGS & INVESTMENTS', 'INCOME',   NULL, NULL),
+    ('TRANSFERS',             'EXCLUDED', NULL, NULL);
+
+-- HOUSING subcategories
+INSERT INTO category (name, type, user_id, parent_id)
+SELECT sub.name, 'EXPENSE', NULL, c.id
+FROM (VALUES ('RENT'), ('UTILITIES'), ('WATER'), ('ELECTRICITY'), ('INTERNET'), ('APPLIANCES')) AS sub(name)
+CROSS JOIN (SELECT id FROM category WHERE name = 'HOUSING' AND parent_id IS NULL AND user_id IS NULL) AS c;
+
+-- FOOD & DINING subcategories
+INSERT INTO category (name, type, user_id, parent_id)
+SELECT sub.name, 'EXPENSE', NULL, c.id
+FROM (VALUES ('RESTAURANTS'), ('GROCERIES'), ('COFFEE & SNACKS')) AS sub(name)
+CROSS JOIN (SELECT id FROM category WHERE name = 'FOOD & DINING' AND parent_id IS NULL AND user_id IS NULL) AS c;
+
+-- TRANSPORT subcategories
+INSERT INTO category (name, type, user_id, parent_id)
+SELECT sub.name, 'EXPENSE', NULL, c.id
+FROM (VALUES ('CAR'), ('GASOLINE'), ('CAR TOOL'), ('PUBLIC TRANSPORT')) AS sub(name)
+CROSS JOIN (SELECT id FROM category WHERE name = 'TRANSPORT' AND parent_id IS NULL AND user_id IS NULL) AS c;
+
+-- HEALTH subcategories
+INSERT INTO category (name, type, user_id, parent_id)
+SELECT sub.name, 'EXPENSE', NULL, c.id
+FROM (VALUES ('HEALTH & WELLNESS'), ('GYM'), ('PSYCHOLOGY')) AS sub(name)
+CROSS JOIN (SELECT id FROM category WHERE name = 'HEALTH' AND parent_id IS NULL AND user_id IS NULL) AS c;
+
+-- SUBSCRIPTIONS subcategories
+INSERT INTO category (name, type, user_id, parent_id)
+SELECT sub.name, 'EXPENSE', NULL, c.id
+FROM (VALUES ('NETFLIX'), ('PRIME'), ('APPLE'), ('NESPRESSO'), ('MOBILE')) AS sub(name)
+CROSS JOIN (SELECT id FROM category WHERE name = 'SUBSCRIPTIONS' AND parent_id IS NULL AND user_id IS NULL) AS c;
+
+-- TRAVEL subcategories
+INSERT INTO category (name, type, user_id, parent_id)
+SELECT sub.name, 'EXPENSE', NULL, c.id
+FROM (VALUES ('FLIGHTS'), ('ACCOMMODATION')) AS sub(name)
+CROSS JOIN (SELECT id FROM category WHERE name = 'TRAVEL' AND parent_id IS NULL AND user_id IS NULL) AS c;
+
+-- ENTERTAINMENT subcategories
+INSERT INTO category (name, type, user_id, parent_id)
+SELECT sub.name, 'EXPENSE', NULL, c.id
+FROM (VALUES ('FUN MONEY'), ('HOBBIES')) AS sub(name)
+CROSS JOIN (SELECT id FROM category WHERE name = 'ENTERTAINMENT' AND parent_id IS NULL AND user_id IS NULL) AS c;
+
+-- MISCELLANEOUS subcategories
+INSERT INTO category (name, type, user_id, parent_id)
+SELECT sub.name, 'EXPENSE', NULL, c.id
+FROM (VALUES ('OTHERS')) AS sub(name)
+CROSS JOIN (SELECT id FROM category WHERE name = 'MISCELLANEOUS' AND parent_id IS NULL AND user_id IS NULL) AS c;
+
+-- INCOME subcategories
+INSERT INTO category (name, type, user_id, parent_id)
+SELECT sub.name, 'INCOME', NULL, c.id
+FROM (VALUES ('SALARY'), ('FREELANCE'), ('OTHER INCOME')) AS sub(name)
+CROSS JOIN (SELECT id FROM category WHERE name = 'INCOME' AND parent_id IS NULL AND user_id IS NULL) AS c;
+
+-- SAVINGS & INVESTMENTS subcategories
+INSERT INTO category (name, type, user_id, parent_id)
+SELECT sub.name, 'INCOME', NULL, c.id
+FROM (VALUES ('SAVINGS'), ('INVESTMENTS')) AS sub(name)
+CROSS JOIN (SELECT id FROM category WHERE name = 'SAVINGS & INVESTMENTS' AND parent_id IS NULL AND user_id IS NULL) AS c;
+
+-- TRANSFERS subcategories (EXCLUDED - internal transfers, no budgeting impact)
+INSERT INTO category (name, type, user_id, parent_id)
+SELECT sub.name, 'EXCLUDED', NULL, c.id
+FROM (VALUES ('TRANSFER BETWEEN ACCOUNTS'), ('FINANCIAL EXPENSES')) AS sub(name)
+CROSS JOIN (SELECT id FROM category WHERE name = 'TRANSFERS' AND parent_id IS NULL AND user_id IS NULL) AS c;

--- a/classifier/src/main/java/com/moneymind/classifier/WekaRandomForestClassifier.java
+++ b/classifier/src/main/java/com/moneymind/classifier/WekaRandomForestClassifier.java
@@ -1,29 +1,31 @@
 package com.moneymind.classifier;
 
 import com.moneymind.classifier.domain.ClassificationResult;
+import com.moneymind.classifier.domain.FeatureExtractor;
 import com.moneymind.classifier.domain.Transaction;
-import com.moneymind.classifier.domain.PartialTransaction;
 import com.moneymind.classifier.ports.Classifier;
 import com.moneymind.classifier.ports.TrainingDataService;
 import weka.classifiers.trees.RandomForest;
 import weka.core.*;
 
 import java.util.*;
-import java.util.stream.IntStream;
 
 /**
- * Vibe coded
+ * Weka RandomForest classifier wired to the pure {@link FeatureExtractor} (ADR-0001): it trains
+ * and predicts on TF-IDF(description) + a nominal bucketed amount range + a nominal day-of-month
+ * period — never exact amounts or dates.
  */
 public class WekaRandomForestClassifier implements Classifier {
     private static final int MIN_TRAINING_SAMPLES = 10;
     private static final double MIN_CONFIDENCE_THRESHOLD = 0.6;
 
     private final TrainingDataService trainingDataService;
+    private final FeatureExtractor featureExtractor;
     private RandomForest model;
     private String[] categoryLabels;
     private Map<String, Integer> categoryToIndex;
     private Map<String, Double> wordFeatures;
-    private double minAmount, maxAmount;
+    private List<String> vocabulary;
 
     public WekaRandomForestClassifier(TrainingDataService trainingDataService) throws Exception {
         // Ensure headless mode for server environments
@@ -31,6 +33,7 @@ public class WekaRandomForestClassifier implements Classifier {
 
         WekaPackageManager.loadPackages(false);
         this.trainingDataService = trainingDataService;
+        this.featureExtractor = new FeatureExtractor();
         this.categoryToIndex = new HashMap<>();
         trainModel();
     }
@@ -42,11 +45,9 @@ public class WekaRandomForestClassifier implements Classifier {
             throw new IllegalStateException("Insufficient training data. Need at least " + MIN_TRAINING_SAMPLES + " samples");
         }
 
-        // Build vocabulary from training data
+        // Build vocabulary (idf weights) from training data, keeping a stable word ordering
         this.wordFeatures = buildVocabulary(trainingData);
-
-        // Prepare features
-        double[][] features = extractFeatures(trainingData);
+        this.vocabulary = new ArrayList<>(wordFeatures.keySet());
 
         // Prepare labels
         Set<String> uniqueCategories = new HashSet<>();
@@ -55,23 +56,16 @@ public class WekaRandomForestClassifier implements Classifier {
         this.categoryLabels = uniqueCategories.toArray(new String[0]);
         Arrays.sort(categoryLabels); // Ensure consistent ordering
 
+        categoryToIndex.clear();
         for (int i = 0; i < categoryLabels.length; i++) {
             categoryToIndex.put(categoryLabels[i], i);
         }
 
-        int[] labels = trainingData.stream()
-                .mapToInt(t -> categoryToIndex.get(t.category()))
-                .toArray();
-
-        // Calculate amount range for normalization
-        List<Double> amounts = trainingData.stream()
-                .map(t -> t.amount().doubleValue())
-                .toList();
-        this.minAmount = amounts.stream().mapToDouble(Double::doubleValue).min().orElse(0.0);
-        this.maxAmount = amounts.stream().mapToDouble(Double::doubleValue).max().orElse(1.0);
-
-        // Create Weka Instances for training
-        Instances trainingInstances = createWekaInstances(features, labels, true);
+        // Create Weka Instances for training (one row per labeled transaction)
+        Instances trainingInstances = newInstances(true);
+        for (Transaction transaction : trainingData) {
+            addInstance(trainingInstances, transaction, transaction.category());
+        }
 
         // Train Weka RandomForest classifier
         this.model = new RandomForest();
@@ -87,14 +81,14 @@ public class WekaRandomForestClassifier implements Classifier {
 
         // Count word frequencies
         for (Transaction transaction : transactions) {
-            Set<String> words = extractWords(transaction.description());
+            Set<String> words = featureExtractor.tokens(transaction.description());
             for (String word : words) {
                 wordCount.put(word, wordCount.getOrDefault(word, 0) + 1);
             }
         }
 
-        // Calculate TF-IDF weights for top words
-        Map<String, Double> vocabulary = new HashMap<>();
+        // Calculate TF-IDF weights for top words, preserving insertion order for stable indexing
+        Map<String, Double> vocabulary = new LinkedHashMap<>();
         wordCount.entrySet().stream()
                 .filter(entry -> entry.getValue() > 1) // Filter rare words
                 .sorted(Map.Entry.<String, Integer>comparingByValue().reversed())
@@ -107,87 +101,48 @@ public class WekaRandomForestClassifier implements Classifier {
         return vocabulary;
     }
 
-    private Set<String> extractWords(String description) {
-        Set<String> words = new HashSet<>();
-        String[] tokens = description.toLowerCase()
-                .replaceAll("[^a-zA-Z0-9\\s]", " ")
-                .split("\\s+");
-
-        for (String token : tokens) {
-            if (token.length() > 2) { // Filter short words
-                words.add(token);
-            }
-        }
-        return words;
-    }
-
-    private double[][] extractFeatures(List<Transaction> transactions) {
-        int numFeatures = wordFeatures.size() + 1; // +1 for amount
-        double[][] features = new double[transactions.size()][numFeatures];
-
-        for (int i = 0; i < transactions.size(); i++) {
-            Transaction transaction = transactions.get(i);
-
-            // Text features using TF-IDF
-            Set<String> words = extractWords(transaction.description());
-            int featureIndex = 0;
-            for (String word : wordFeatures.keySet()) {
-                double tf = words.contains(word) ? 1.0 : 0.0;
-                double idf = wordFeatures.get(word);
-                features[i][featureIndex] = tf * idf;
-                featureIndex++;
-            }
-
-            // Amount feature (normalized)
-            double normalizedAmount = (transaction.amount().doubleValue() - minAmount) /
-                                    (maxAmount - minAmount + 1e-6); // Avoid division by zero
-            features[i][featureIndex] = normalizedAmount;
-        }
-
-        return features;
-    }
-
-    private Instances createWekaInstances(double[][] features, int[] labels, boolean withLabels) {
-        // Create attribute list
+    /** Attribute layout: word_0..word_n (numeric tf-idf), amount_bucket (nominal), period (nominal), [class]. */
+    private Instances newInstances(boolean withLabels) {
         ArrayList<Attribute> attributes = new ArrayList<>();
 
-        // Add feature attributes
-        for (int i = 0; i < wordFeatures.size(); i++) {
+        for (int i = 0; i < vocabulary.size(); i++) {
             attributes.add(new Attribute("word_" + i));
         }
-        attributes.add(new Attribute("amount"));
+        attributes.add(new Attribute("amount_bucket", FeatureExtractor.AMOUNT_BUCKETS));
+        attributes.add(new Attribute("period", FeatureExtractor.PERIODS));
 
-        // Add class attribute if needed
         if (withLabels) {
-            ArrayList<String> classValues = new ArrayList<>(Arrays.asList(categoryLabels));
-            attributes.add(new Attribute("class", classValues));
+            attributes.add(new Attribute("class", new ArrayList<>(Arrays.asList(categoryLabels))));
         }
 
-        // Create instances
-        Instances instances = new Instances("TransactionClassification", attributes, features.length);
+        Instances instances = new Instances("TransactionClassification", attributes, 0);
         if (withLabels) {
             instances.setClassIndex(instances.numAttributes() - 1);
         }
+        return instances;
+    }
 
-        // Add data
-        for (int i = 0; i < features.length; i++) {
-            Instance instance = new DenseInstance(attributes.size());
-            instance.setDataset(instances);
+    /** Builds a feature row for the transaction and appends it to {@code dataset}. */
+    private void addInstance(Instances dataset, Transaction transaction, String label) {
+        Instance instance = new DenseInstance(dataset.numAttributes());
+        instance.setDataset(dataset);
 
-            // Set feature values
-            for (int j = 0; j < features[i].length; j++) {
-                instance.setValue(j, features[i][j]);
-            }
-
-            // Set class value if provided
-            if (withLabels) {
-                instance.setValue(instances.classIndex(), categoryLabels[labels[i]]);
-            }
-
-            instances.add(instance);
+        Set<String> tokens = featureExtractor.tokens(transaction.description());
+        for (int i = 0; i < vocabulary.size(); i++) {
+            String word = vocabulary.get(i);
+            double tf = tokens.contains(word) ? 1.0 : 0.0;
+            instance.setValue(i, tf * wordFeatures.get(word));
         }
 
-        return instances;
+        int bucketIndex = vocabulary.size();
+        instance.setValue(dataset.attribute(bucketIndex), featureExtractor.amountBucket(transaction.amount()));
+        instance.setValue(dataset.attribute(bucketIndex + 1), featureExtractor.period(transaction.date()));
+
+        if (label != null && dataset.classIndex() >= 0) {
+            instance.setValue(dataset.classIndex(), label);
+        }
+
+        dataset.add(instance);
     }
 
     private WekaResult categorizeWithConfidence(Transaction transaction) throws Exception {
@@ -195,36 +150,9 @@ public class WekaRandomForestClassifier implements Classifier {
             throw new IllegalStateException("Model not trained");
         }
 
-        // Extract features for the transaction
-        double[] transactionFeatures = extractFeatures(transaction);
-
-        // Create Weka instance for prediction (add dummy class attribute)
-        ArrayList<Attribute> attributes = new ArrayList<>();
-
-        // Add feature attributes
-        for (int i = 0; i < wordFeatures.size(); i++) {
-            attributes.add(new Attribute("word_" + i));
-        }
-        attributes.add(new Attribute("amount"));
-
-        // Add class attribute
-        ArrayList<String> classValues = new ArrayList<>(Arrays.asList(categoryLabels));
-        attributes.add(new Attribute("class", classValues));
-
-        Instances predictionInstances = new Instances("TransactionClassification", attributes, 1);
-        predictionInstances.setClassIndex(predictionInstances.numAttributes() - 1);
-
-        Instance instance = new DenseInstance(attributes.size());
-        instance.setDataset(predictionInstances);
-
-        // Set feature values
-        for (int j = 0; j < transactionFeatures.length; j++) {
-            instance.setValue(j, transactionFeatures[j]);
-        }
-        // Class value will be missing for prediction
-
-        predictionInstances.add(instance);
-        instance = predictionInstances.firstInstance();
+        Instances predictionInstances = newInstances(true);
+        addInstance(predictionInstances, transaction, null); // class value left missing
+        Instance instance = predictionInstances.firstInstance();
 
         // Get prediction from RandomForest
         double predictedIndex = model.classifyInstance(instance);
@@ -238,28 +166,6 @@ public class WekaRandomForestClassifier implements Classifier {
         boolean isHighConfidence = confidence >= MIN_CONFIDENCE_THRESHOLD;
 
         return new WekaResult(predictedCategory, confidence, isHighConfidence);
-    }
-
-    private double[] extractFeatures(Transaction transaction) {
-        int numFeatures = wordFeatures.size() + 1;
-        double[] features = new double[numFeatures];
-
-        // Text features using TF-IDF
-        Set<String> words = extractWords(transaction.description());
-        int featureIndex = 0;
-        for (String word : wordFeatures.keySet()) {
-            double tf = words.contains(word) ? 1.0 : 0.0;
-            double idf = wordFeatures.get(word);
-            features[featureIndex] = tf * idf;
-            featureIndex++;
-        }
-
-        // Amount feature (normalized)
-        double normalizedAmount = (transaction.amount().doubleValue() - minAmount) /
-                                (maxAmount - minAmount + 1e-6); // Avoid division by zero
-        features[featureIndex] = normalizedAmount;
-
-        return features;
     }
 
     public void retrainModel() throws Exception {

--- a/classifier/src/main/java/com/moneymind/classifier/domain/FeatureExtractor.java
+++ b/classifier/src/main/java/com/moneymind/classifier/domain/FeatureExtractor.java
@@ -1,0 +1,111 @@
+package com.moneymind.classifier.domain;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Pure, deterministic feature extraction for the auto-classifier (ADR-0001).
+ *
+ * <p>Turns a {@link Transaction} into a {@link Features} view that the Weka model trains and
+ * predicts on: tokenized description (TF-IDF input) + a bucketed amount range + a day-of-month
+ * period. It deliberately keeps no exact amount and no exact date so the shared global model
+ * never embeds precise financial detail (GDPR-defensible).
+ *
+ * <p>No DB, no framework, no mutable state — safe to instantiate freely and to unit-test directly.
+ */
+public final class FeatureExtractor {
+
+    public static final String UNKNOWN = "unknown";
+
+    public static final String EARLY = "early";
+    public static final String MID = "mid";
+    public static final String LATE = "late";
+
+    /** Day-of-month boundaries: 1..10 early, 11..20 mid, 21..31 late. */
+    private static final int EARLY_LAST_DAY = 10;
+    private static final int MID_LAST_DAY = 20;
+
+    /** Half-open [lower, upper) buckets keyed off the magnitude (absolute value) of the amount. */
+    private static final BigDecimal[] BUCKET_UPPER_BOUNDS = {
+            new BigDecimal("10"),
+            new BigDecimal("50"),
+            new BigDecimal("100"),
+            new BigDecimal("500"),
+            new BigDecimal("1000"),
+            new BigDecimal("5000"),
+    };
+    private static final String[] BUCKET_LABELS = {
+            "0-10", "10-50", "50-100", "100-500", "500-1000", "1000-5000", "5000+",
+    };
+
+    /** Nominal values for the amount-bucket Weka attribute (includes {@link #UNKNOWN}). */
+    public static final List<String> AMOUNT_BUCKETS = List.of(
+            "0-10", "10-50", "50-100", "100-500", "500-1000", "1000-5000", "5000+", UNKNOWN);
+
+    /** Nominal values for the period Weka attribute (includes {@link #UNKNOWN}). */
+    public static final List<String> PERIODS = List.of(EARLY, MID, LATE, UNKNOWN);
+
+    private static final int MIN_TOKEN_LENGTH = 3;
+
+    public Features extract(Transaction transaction) {
+        return new Features(
+                tokens(transaction.description()),
+                amountBucket(transaction.amount()),
+                period(transaction.date()));
+    }
+
+    /**
+     * Lowercase, strip non-alphanumerics, keep tokens longer than two characters. Null/empty/fully
+     * masked descriptions yield an empty set (the amount + period features still carry signal).
+     */
+    public Set<String> tokens(String description) {
+        Set<String> tokens = new LinkedHashSet<>();
+        if (description == null || description.isBlank()) {
+            return tokens;
+        }
+        String[] candidates = description.toLowerCase()
+                .replaceAll("[^a-z0-9\\s]", " ")
+                .split("\\s+");
+        for (String candidate : candidates) {
+            if (candidate.length() >= MIN_TOKEN_LENGTH) {
+                tokens.add(candidate);
+            }
+        }
+        return tokens;
+    }
+
+    /**
+     * Maps the amount's magnitude to a half-open {@code [lower, upper)} range label; an edge value
+     * lands in the upper bucket (e.g. 500.00 → "500-1000"). Null → {@link #UNKNOWN}.
+     */
+    public String amountBucket(BigDecimal amount) {
+        if (amount == null) {
+            return UNKNOWN;
+        }
+        BigDecimal magnitude = amount.abs();
+        for (int i = 0; i < BUCKET_UPPER_BOUNDS.length; i++) {
+            if (magnitude.compareTo(BUCKET_UPPER_BOUNDS[i]) < 0) {
+                return BUCKET_LABELS[i];
+            }
+        }
+        return BUCKET_LABELS[BUCKET_LABELS.length - 1];
+    }
+
+    /** Day-of-month → early/mid/late. Null date → {@link #UNKNOWN}. */
+    public String period(LocalDate date) {
+        if (date == null) {
+            return UNKNOWN;
+        }
+        int day = date.getDayOfMonth();
+        if (day <= EARLY_LAST_DAY) {
+            return EARLY;
+        }
+        if (day <= MID_LAST_DAY) {
+            return MID;
+        }
+        return LATE;
+    }
+}

--- a/classifier/src/main/java/com/moneymind/classifier/domain/Features.java
+++ b/classifier/src/main/java/com/moneymind/classifier/domain/Features.java
@@ -1,0 +1,11 @@
+package com.moneymind.classifier.domain;
+
+import java.util.Set;
+
+/**
+ * The GDPR-defensible feature representation of a Transaction (per ADR-0001):
+ * tokenized description (fed to TF-IDF), a bucketed amount range, and a
+ * day-of-month period. It carries no exact amount and no exact date.
+ */
+public record Features(Set<String> tokens, String amountBucket, String period) {
+}

--- a/classifier/src/main/java/com/moneymind/classifier/domain/Transaction.java
+++ b/classifier/src/main/java/com/moneymind/classifier/domain/Transaction.java
@@ -1,6 +1,7 @@
 package com.moneymind.classifier.domain;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 
-public record Transaction(String description, String category, BigDecimal amount) {
+public record Transaction(String description, String category, BigDecimal amount, LocalDate date) {
 }

--- a/classifier/src/main/java/com/moneymind/classifier/infrastructure/postgres/TransactionRepository.java
+++ b/classifier/src/main/java/com/moneymind/classifier/infrastructure/postgres/TransactionRepository.java
@@ -8,8 +8,8 @@ import org.jooq.Result;
 import org.jooq.SelectConditionStep;
 
 import java.math.BigDecimal;
+import java.time.OffsetDateTime;
 import java.util.List;
-import java.util.stream.Stream;
 
 public class TransactionRepository implements TrainingDataService {
 
@@ -27,8 +27,13 @@ public class TransactionRepository implements TrainingDataService {
                 new Transaction(
                         record.get("description", String.class),
                         record.get("category", String.class),
-                        record.get("value", BigDecimal.class)
+                        record.get("value", BigDecimal.class),
+                        toLocalDate(record.get("date", OffsetDateTime.class))
                 )).toList();
         return list;
+    }
+
+    private static java.time.LocalDate toLocalDate(OffsetDateTime date) {
+        return date == null ? null : date.toLocalDate();
     }
 }

--- a/classifier/src/test/java/com/moneymind/classifier/domain/FeatureExtractorTest.java
+++ b/classifier/src/test/java/com/moneymind/classifier/domain/FeatureExtractorTest.java
@@ -1,0 +1,117 @@
+package com.moneymind.classifier.domain;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pure unit tests (no mocks) for {@link FeatureExtractor}, covering the boundary behaviour the
+ * classifier depends on: amount-bucket edges, day-of-month period edges, and masked/empty
+ * descriptions (ADR-0001).
+ */
+class FeatureExtractorTest {
+
+    private final FeatureExtractor extractor = new FeatureExtractor();
+
+    @ParameterizedTest
+    @CsvSource({
+            // value, expected bucket — edges land in the UPPER half-open bucket
+            "0,        0-10",
+            "9.99,     0-10",
+            "10,       10-50",
+            "49.99,    10-50",
+            "50,       50-100",
+            "99.99,    50-100",
+            "100,      100-500",
+            "499.99,   100-500",
+            "500,      500-1000",
+            "999.99,   500-1000",
+            "1000,     1000-5000",
+            "4999.99,  1000-5000",
+            "5000,     5000+",
+            "12345.67, 5000+",
+    })
+    void amountBucket_mapsEdgesToCorrectBucket(String amount, String expected) {
+        assertEquals(expected, extractor.amountBucket(new BigDecimal(amount)));
+    }
+
+    @Test
+    void amountBucket_usesMagnitudeForNegativeAmounts() {
+        assertEquals("500-1000", extractor.amountBucket(new BigDecimal("-500")));
+        assertEquals("0-10", extractor.amountBucket(new BigDecimal("-9.99")));
+    }
+
+    @Test
+    void amountBucket_nullIsUnknown() {
+        assertEquals(FeatureExtractor.UNKNOWN, extractor.amountBucket(null));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "1,  early",
+            "10, early",  // early -> mid boundary
+            "11, mid",
+            "20, mid",    // mid -> late boundary
+            "21, late",
+            "28, late",
+    })
+    void period_mapsDayOfMonthEdgesToCorrectPeriod(int day, String expected) {
+        assertEquals(expected, extractor.period(LocalDate.of(2026, 2, day)));
+    }
+
+    @Test
+    void period_nullDateIsUnknown() {
+        assertEquals(FeatureExtractor.UNKNOWN, extractor.period(null));
+    }
+
+    @Test
+    void tokens_lowercasesStripsAndDropsShortTokens() {
+        // "PT" (len 2) is dropped; "com" (len 3) is kept
+        assertEquals(java.util.Set.of("netflix", "com", "lisboa"), extractor.tokens("NETFLIX.COM, Lisboa PT"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"*******", "12 9*", "  "})
+    void tokens_maskedOrShortDescriptionsYieldEmptySet(String description) {
+        assertTrue(extractor.tokens(description).isEmpty(),
+                () -> "expected no usable tokens for: " + description);
+    }
+
+    @Test
+    void tokens_nullAndEmptyDescriptionsAreEmpty() {
+        assertTrue(extractor.tokens(null).isEmpty());
+        assertTrue(extractor.tokens("").isEmpty());
+    }
+
+    @Test
+    void extract_maskedDescriptionStillYieldsUsableAmountAndPeriodFeatures() {
+        Transaction masked = new Transaction(
+                "351 9******* transfer", "INCOME", new BigDecimal("1200.00"), LocalDate.of(2026, 1, 2));
+
+        Features features = extractor.extract(masked);
+
+        // Amount + period signal survives even though the description is largely masked
+        assertEquals("1000-5000", features.amountBucket());
+        assertEquals(FeatureExtractor.EARLY, features.period());
+        assertTrue(features.tokens().contains("transfer"));
+    }
+
+    @Test
+    void extract_fullyMaskedDescriptionDropsToAmountAndPeriodOnly() {
+        Transaction masked = new Transaction(
+                "*******", "EXPENSE", new BigDecimal("-9.99"), LocalDate.of(2026, 1, 25));
+
+        Features features = extractor.extract(masked);
+
+        assertTrue(features.tokens().isEmpty());
+        assertEquals("0-10", features.amountBucket());
+        assertEquals(FeatureExtractor.LATE, features.period());
+    }
+}


### PR DESCRIPTION
  Implemented Issue 0002 — Classifier FeatureExtractor as the next task (a no-blocker, no-HITL tracer bullet that unblocks 0004 and 0009).

  What was built:
  - FeatureExtractor (new, pure, no DB/framework) — turns a Transaction into the ADR-0001 feature view: tokenized description (TF-IDF input) + bucketed amount range + day-of-month period. Features record holds the output.
  - Transaction gained a LocalDate date (needed for the period feature); the two construction sites (TransactionRepository, ClassificationEngine) now pass it null-safely.
  - WekaRandomForestClassifier rewired to consume the extractor: nominal amount_bucket + period attributes replace the old min-max-normalized exact amount (the GDPR violation per ADR-0001).
  - FeatureExtractorTest — 30 tests, no mocks, covering bucket edges, period edges, and masked/empty descriptions.
