### PR TITLE
RALPH: TransactionQuery deep module — all query shapes (issue 0003)

### DIFF
--- a/app/src/main/java/com/moneymind/finance/domain/core/AggregationPeriod.java
+++ b/app/src/main/java/com/moneymind/finance/domain/core/AggregationPeriod.java
@@ -1,0 +1,27 @@
+package com.moneymind.finance.domain.core;
+
+public enum AggregationPeriod {
+    YEAR("year", "YYYY"),
+    MONTH("month", "YYYY-MM");
+
+    private final String sqlTruncation;
+    private final String dateFormat;
+
+    AggregationPeriod(String sqlTruncation, String dateFormat) {
+        this.sqlTruncation = sqlTruncation;
+        this.dateFormat = dateFormat;
+    }
+
+    public String getSqlTruncation() {
+        return sqlTruncation;
+    }
+
+    public String getDateFormat() {
+        return dateFormat;
+    }
+
+    public static AggregationPeriod fromString(String period) {
+        if (period == null || period.isEmpty()) return null;
+        return period.equalsIgnoreCase("year") ? YEAR : MONTH;
+    }
+}

--- a/app/src/main/java/com/moneymind/finance/infrastructure/postgres/TransactionQuery.java
+++ b/app/src/main/java/com/moneymind/finance/infrastructure/postgres/TransactionQuery.java
@@ -1,0 +1,251 @@
+package com.moneymind.finance.infrastructure.postgres;
+
+import com.moneymind.finance.domain.PagedResult;
+import com.moneymind.finance.domain.core.AggregatedResult;
+import com.moneymind.finance.domain.core.AggregationPeriod;
+import com.moneymind.finance.domain.core.Cursor;
+import com.moneymind.finance.domain.core.FinancialRecord;
+import com.moneymind.finance.domain.core.TransactionSearchQuery;
+import org.jooq.DSLContext;
+import org.jooq.Record;
+import org.jooq.Record2;
+import org.jooq.Record3;
+import org.jooq.Result;
+import org.jooq.Select;
+import org.jooq.SelectConditionStep;
+import org.jooq.SelectJoinStep;
+import org.jooq.SortField;
+import org.jooq.generated.tables.BankTransaction;
+import org.jooq.generated.tables.records.BankTransactionRecord;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static org.jooq.impl.DSL.sum;
+
+class TransactionQuery extends Store {
+
+    private final DSLContext dsl;
+
+    TransactionQuery(DSLContext dsl) {
+        this.dsl = dsl;
+    }
+
+    // ─── public API ───────────────────────────────────────────────────────────
+
+    PagedResult<FinancialRecord> search(TransactionSearchQuery query) {
+        int limit = sanitizeLimit(query.limit());
+        Result<BankTransactionRecord> results = buildSearchSelect(query).fetch();
+
+        String newCursor = null;
+        if (results.size() > limit) {
+            newCursor = Cursor.forId(results.remove(results.size() - 1).getId());
+        }
+
+        return new PagedResult<>(
+                results.stream().map(TransactionStore::toModel).collect(Collectors.toList()),
+                limit,
+                newCursor
+        );
+    }
+
+    PagedResult<AggregatedResult> searchAggregated(TransactionSearchQuery query) {
+        boolean hasPeriod = hasValue(query.aggregateByPeriod());
+        boolean hasColumn = hasValue(query.aggregateByColumn());
+
+        if (hasPeriod && hasColumn) return byPeriodAndColumn(query);
+        if (hasPeriod) return byPeriod(query);
+        return byColumn(query);
+    }
+
+    // ─── package-private builders (for rendered-SQL tests) ───────────────────
+
+    Select<BankTransactionRecord> buildSearchSelect(TransactionSearchQuery query) {
+        int limit = sanitizeLimit(query.limit());
+        int cursor = sanitizeCursor(query.cursor());
+
+        SelectConditionStep<BankTransactionRecord> q = dsl
+                .selectFrom(BankTransaction.BANK_TRANSACTION)
+                .where(BankTransaction.BANK_TRANSACTION.ID.ge(cursor));
+
+        q = applyCommonFilters(q, query);
+        return q.orderBy(buildSortFields(query.sort())).limit(limit + 1);
+    }
+
+    Select<?> buildByPeriodSelect(TransactionSearchQuery query) {
+        AggregationPeriod period = AggregationPeriod.fromString(query.aggregateByPeriod());
+        String trunc = period.getSqlTruncation();
+        String fmt = period.getDateFormat();
+        int limit = sanitizeLimit(query.limit());
+
+        SelectJoinStep<Record2<String, BigDecimal>> from = dsl
+                .select(
+                        org.jooq.impl.DSL.field(
+                                "TO_CHAR(DATE_TRUNC('" + trunc + "', {0}), '" + fmt + "')",
+                                String.class,
+                                BankTransaction.BANK_TRANSACTION.DATE
+                        ).as("period"),
+                        sum(BankTransaction.BANK_TRANSACTION.VALUE).as("total")
+                )
+                .from(BankTransaction.BANK_TRANSACTION);
+
+        SelectConditionStep<Record2<String, BigDecimal>> where =
+                applyDateFilters(from, query.from(), query.to());
+
+        return (where != null ? where : from)
+                .groupBy(org.jooq.impl.DSL.field("DATE_TRUNC('" + trunc + "', {0})", BankTransaction.BANK_TRANSACTION.DATE))
+                .orderBy(org.jooq.impl.DSL.field("period").asc())
+                .limit(limit + 1);
+    }
+
+    Select<?> buildByColumnSelect(TransactionSearchQuery query) {
+        SelectJoinStep<Record2<String, BigDecimal>> from = dsl
+                .select(
+                        BankTransaction.BANK_TRANSACTION.field(query.aggregateByColumn(), String.class),
+                        sum(BankTransaction.BANK_TRANSACTION.VALUE).as("total")
+                )
+                .from(BankTransaction.BANK_TRANSACTION);
+
+        SelectConditionStep<Record2<String, BigDecimal>> where =
+                applyDateFilters(from, query.from(), query.to());
+
+        return (where != null ? where : from)
+                .groupBy(BankTransaction.BANK_TRANSACTION.field(query.aggregateByColumn()));
+    }
+
+    Select<?> buildByPeriodAndColumnSelect(TransactionSearchQuery query) {
+        AggregationPeriod period = AggregationPeriod.fromString(query.aggregateByPeriod());
+        String trunc = period.getSqlTruncation();
+        String fmt = period.getDateFormat();
+
+        SelectJoinStep<Record3<String, String, BigDecimal>> from = dsl
+                .select(
+                        org.jooq.impl.DSL.field(
+                                "TO_CHAR(DATE_TRUNC('" + trunc + "', {0}), '" + fmt + "')",
+                                String.class,
+                                BankTransaction.BANK_TRANSACTION.DATE
+                        ).as("period"),
+                        BankTransaction.BANK_TRANSACTION.CATEGORY,
+                        sum(BankTransaction.BANK_TRANSACTION.VALUE).as("total")
+                )
+                .from(BankTransaction.BANK_TRANSACTION);
+
+        SelectConditionStep<Record3<String, String, BigDecimal>> where =
+                applyDateFilters(from, query.from(), query.to());
+
+        return (where != null ? where : from)
+                .groupBy(
+                        org.jooq.impl.DSL.field("DATE_TRUNC('" + trunc + "', {0})", BankTransaction.BANK_TRANSACTION.DATE),
+                        BankTransaction.BANK_TRANSACTION.CATEGORY
+                )
+                .orderBy(
+                        org.jooq.impl.DSL.field("period").asc(),
+                        BankTransaction.BANK_TRANSACTION.CATEGORY.asc()
+                )
+                .limit(sanitizeLimit(query.limit()) + 1);
+    }
+
+    // ─── private execution wrappers ──────────────────────────────────────────
+
+    @SuppressWarnings("unchecked")
+    private PagedResult<AggregatedResult> byPeriod(TransactionSearchQuery query) {
+        int limit = sanitizeLimit(query.limit());
+        Result<Record2<String, BigDecimal>> results =
+                (Result<Record2<String, BigDecimal>>) buildByPeriodSelect(query).fetch();
+
+        String newCursor = null;
+        if (results.size() > limit) {
+            Record2<String, BigDecimal> last = results.removeLast();
+            newCursor = Cursor.forPeriod(last.get("period", String.class));
+        }
+
+        return new PagedResult<>(
+                results.stream()
+                        .map(r -> new AggregatedResult(r.get("period", String.class), null, r.get("total", BigDecimal.class)))
+                        .toList(),
+                limit,
+                newCursor
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    private PagedResult<AggregatedResult> byColumn(TransactionSearchQuery query) {
+        Result<Record2<String, BigDecimal>> results =
+                (Result<Record2<String, BigDecimal>>) buildByColumnSelect(query).fetch();
+
+        List<AggregatedResult> records = results.stream()
+                .map(r -> new AggregatedResult(null, r.get(0, String.class), r.get("total", BigDecimal.class)))
+                .toList();
+
+        return new PagedResult<>(records, query.limit(), null);
+    }
+
+    @SuppressWarnings("unchecked")
+    private PagedResult<AggregatedResult> byPeriodAndColumn(TransactionSearchQuery query) {
+        Result<Record3<String, String, BigDecimal>> results =
+                (Result<Record3<String, String, BigDecimal>>) buildByPeriodAndColumnSelect(query).fetch();
+
+        List<AggregatedResult> records = results.stream()
+                .map(r -> new AggregatedResult(
+                        r.get("period", String.class),
+                        r.get(BankTransaction.BANK_TRANSACTION.CATEGORY),
+                        r.get("total", BigDecimal.class)
+                ))
+                .toList();
+
+        return new PagedResult<>(records, query.limit(), null);
+    }
+
+    // ─── private helpers ─────────────────────────────────────────────────────
+
+    private <R extends Record> SelectConditionStep<R> applyDateFilters(
+            SelectJoinStep<R> from, String fromDate, String toDate) {
+        SelectConditionStep<R> where = null;
+        if (hasValue(fromDate)) {
+            where = from.where(BankTransaction.BANK_TRANSACTION.DATE.greaterOrEqual(OffsetDateTime.parse(fromDate)));
+        }
+        if (hasValue(toDate)) {
+            where = where != null
+                    ? where.and(BankTransaction.BANK_TRANSACTION.DATE.lessOrEqual(OffsetDateTime.parse(toDate)))
+                    : from.where(BankTransaction.BANK_TRANSACTION.DATE.lessOrEqual(OffsetDateTime.parse(toDate)));
+        }
+        return where;
+    }
+
+    private SelectConditionStep<BankTransactionRecord> applyCommonFilters(
+            SelectConditionStep<BankTransactionRecord> where, TransactionSearchQuery q) {
+        if (hasValue(q.id()))
+            where = where.and(BankTransaction.BANK_TRANSACTION.UUID.eq(UUID.fromString(q.id())));
+        if (hasValue(q.category()))
+            where = where.and(BankTransaction.BANK_TRANSACTION.CATEGORY.eq(q.category()));
+        if (hasValue(q.bank()))
+            where = where.and(BankTransaction.BANK_TRANSACTION.BANK_NAME.eq(q.bank()));
+        if (hasValue(q.from()))
+            where = where.and(BankTransaction.BANK_TRANSACTION.DATE.greaterOrEqual(OffsetDateTime.parse(q.from())));
+        if (hasValue(q.to()))
+            where = where.and(BankTransaction.BANK_TRANSACTION.DATE.lessOrEqual(OffsetDateTime.parse(q.to())));
+        if (q.excludeCategories() != null && !q.excludeCategories().isEmpty())
+            where = where.and(BankTransaction.BANK_TRANSACTION.CATEGORY.notIn(q.excludeCategories()));
+        return where;
+    }
+
+    private List<SortField<?>> buildSortFields(String sort) {
+        if ("ASC".equals(sort)) {
+            return List.of(
+                    BankTransaction.BANK_TRANSACTION.DATE.asc(),
+                    BankTransaction.BANK_TRANSACTION.ID.asc()
+            );
+        }
+        return List.of(
+                BankTransaction.BANK_TRANSACTION.DATE.desc(),
+                BankTransaction.BANK_TRANSACTION.ID.desc()
+        );
+    }
+
+    private boolean hasValue(String s) {
+        return s != null && !s.isEmpty();
+    }
+}

--- a/app/src/main/java/com/moneymind/finance/infrastructure/postgres/TransactionStore.java
+++ b/app/src/main/java/com/moneymind/finance/infrastructure/postgres/TransactionStore.java
@@ -2,19 +2,20 @@ package com.moneymind.finance.infrastructure.postgres;
 
 import com.moneymind.finance.domain.PagedResult;
 import com.moneymind.finance.domain.core.AggregatedResult;
+import com.moneymind.finance.domain.core.Cursor;
 import com.moneymind.finance.domain.core.FinancialRecord;
 import com.moneymind.finance.domain.core.TransactionSearchQuery;
 import com.moneymind.finance.domain.ports.TransactionRepository;
-import org.jooq.*;
+import org.jooq.DSLContext;
+import org.jooq.InsertValuesStep5;
 import org.jooq.Record;
+import org.jooq.Result;
 import org.jooq.exception.IntegrityConstraintViolationException;
 import org.jooq.generated.tables.BankTransaction;
 import org.jooq.generated.tables.records.BankTransactionRecord;
 import org.postgresql.util.PSQLException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.moneymind.finance.domain.core.Cursor;
 
 import java.math.BigDecimal;
 import java.sql.BatchUpdateException;
@@ -24,17 +25,17 @@ import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import static org.jooq.impl.DSL.sum;
-
 public class TransactionStore extends Store implements TransactionRepository {
 
     private static final Logger logger = LoggerFactory.getLogger(TransactionStore.class);
     private static final String PLSQL_DUPLICATED_RECORD_ERROR_CODE = "23505";
 
     final DSLContext dataSource;
+    private final TransactionQuery txQuery;
 
     public TransactionStore(final DSLContext dataSource) {
         this.dataSource = dataSource;
+        this.txQuery = new TransactionQuery(dataSource);
     }
 
     public BankTransactionRecord toRecord(FinancialRecord record) {
@@ -59,6 +60,7 @@ public class TransactionStore extends Store implements TransactionRepository {
                 record.getCategory()
         );
     }
+
     @Override
     public FinancialRecord insertTransaction(FinancialRecord financialRecord) {
         final BankTransactionRecord bankTransactionRecord = toRecord(financialRecord);
@@ -73,7 +75,6 @@ public class TransactionStore extends Store implements TransactionRepository {
         try {
             final List<BankTransactionRecord> transactionRecords = financialRecords.stream().map(this::toRecord).toList();
 
-            // Build multi-row INSERT with RETURNING
             InsertValuesStep5<BankTransactionRecord, BigDecimal, String, OffsetDateTime, BigDecimal, String> insert = null;
 
             for (BankTransactionRecord record : transactionRecords) {
@@ -86,11 +87,9 @@ public class TransactionStore extends Store implements TransactionRepository {
                         record.getBalance(), record.getBankName());
             }
 
-            // Execute with RETURNING to get generated UUIDs
             assert insert != null;
             Result<BankTransactionRecord> insertedRecords = insert.returning().fetch();
 
-            // Return the inserted records with generated IDs
             return insertedRecords.stream()
                     .map(TransactionStore::toModel)
                     .collect(Collectors.toList());
@@ -114,149 +113,12 @@ public class TransactionStore extends Store implements TransactionRepository {
 
     @Override
     public PagedResult<FinancialRecord> search(final TransactionSearchQuery query) {
-        final int sanitizedLimit = this.sanitizeLimit(query.limit());
-        final int sanitizedCursor = this.sanitizeCursor(query.cursor());
-
-        QueryContext context = new QueryContext(dataSource, query, sanitizedLimit, sanitizedCursor);
-        RegularSearchStrategy strategy = new RegularSearchStrategy(new QueryBuilderHelper(), new PaginationHandler());
-        return strategy.execute(context);
+        return txQuery.search(query);
     }
 
     @Override
     public PagedResult<AggregatedResult> searchAggregated(final TransactionSearchQuery query) {
-        boolean hasGroupByColumn = query.aggregateByColumn() != null && !query.aggregateByColumn().isEmpty();
-        boolean hasGroupByPeriod = query.aggregateByPeriod() != null && !query.aggregateByPeriod().isEmpty();
-
-        if (hasGroupByPeriod && hasGroupByColumn) {
-            return buildAggregatedByPeriodAndColumn(query);
-        } else if (hasGroupByPeriod) {
-            return buildAggregatedByPeriod(query);
-        } else {
-            return buildAggregatedByColumn(query);
-        }
-    }
-
-    private PagedResult<AggregatedResult> buildAggregatedByPeriodAndColumn(final TransactionSearchQuery query) {
-        final String truncation = query.aggregateByPeriod().equalsIgnoreCase("year") ? "year" : "month";
-        final String dateFormat = truncation.equals("year") ? "YYYY" : "YYYY-MM";
-
-        final SelectJoinStep<Record3<String, String, BigDecimal>> fromClause = this.dataSource
-                .select(
-                        org.jooq.impl.DSL.field(
-                                "TO_CHAR(DATE_TRUNC('" + truncation + "', {0}), '" + dateFormat + "')",
-                                String.class,
-                                BankTransaction.BANK_TRANSACTION.DATE
-                        ).as("period"),
-                        BankTransaction.BANK_TRANSACTION.CATEGORY,
-                        sum(BankTransaction.BANK_TRANSACTION.VALUE).as("total")
-                )
-                .from(BankTransaction.BANK_TRANSACTION);
-
-        SelectConditionStep<Record3<String, String, BigDecimal>> where =
-                applyDateFilters(fromClause, query.from(), query.to());
-
-        Result<Record3<String, String, BigDecimal>> results = Objects.requireNonNullElse(where, fromClause)
-                .groupBy(
-                        org.jooq.impl.DSL.field("DATE_TRUNC('" + truncation + "', {0})", BankTransaction.BANK_TRANSACTION.DATE),
-                        BankTransaction.BANK_TRANSACTION.CATEGORY
-                )
-                .orderBy(org.jooq.impl.DSL.field("period").asc(), BankTransaction.BANK_TRANSACTION.CATEGORY.asc())
-                .limit(sanitizeLimit(query.limit()) + 1)
-                .fetch();
-
-        List<AggregatedResult> records = results.stream()
-                .map(r -> new AggregatedResult(
-                        r.get("period", String.class),
-                        r.get(BankTransaction.BANK_TRANSACTION.CATEGORY),
-                        r.get("total", BigDecimal.class)
-                ))
-                .toList();
-
-        return new PagedResult<>(records, query.limit(), null);
-    }
-
-    private PagedResult<AggregatedResult> buildAggregatedByPeriod(final TransactionSearchQuery query) {
-        final int sanitizedLimit = this.sanitizeLimit(query.limit());
-        final String truncation = query.aggregateByPeriod().equalsIgnoreCase("year") ? "year" : "month";
-        final String dateFormat = truncation.equals("year") ? "YYYY" : "YYYY-MM";
-
-        final SelectJoinStep<Record2<String, BigDecimal>> fromClause = this.dataSource
-                .select(
-                        org.jooq.impl.DSL.field(
-                                "TO_CHAR(DATE_TRUNC('" + truncation + "', {0}), '" + dateFormat + "')",
-                                String.class,
-                                BankTransaction.BANK_TRANSACTION.DATE
-                        ).as("period"),
-                        sum(BankTransaction.BANK_TRANSACTION.VALUE).as("total")
-                )
-                .from(BankTransaction.BANK_TRANSACTION);
-
-        SelectConditionStep<Record2<String, BigDecimal>> where = applyDateFilters(fromClause, query.from(), query.to());
-
-        Result<Record2<String, BigDecimal>> results = Objects.requireNonNullElse(where, fromClause)
-                .groupBy(org.jooq.impl.DSL.field("DATE_TRUNC('" + truncation + "', {0})", BankTransaction.BANK_TRANSACTION.DATE))
-                .orderBy(org.jooq.impl.DSL.field("period").asc())
-                .limit(sanitizedLimit + 1)
-                .fetch();
-
-        String newCursor = null;
-        if (results.size() > sanitizedLimit) {
-            Record2<String, BigDecimal> last = results.removeLast();
-            newCursor = buildCursor(last, null, query.aggregateByPeriod());
-        }
-
-        List<AggregatedResult> records = results.stream()
-                .map(r -> new AggregatedResult(r.get("period", String.class), null, r.get("total", BigDecimal.class)))
-                .toList();
-
-        return new PagedResult<>(records, sanitizedLimit, newCursor);
-    }
-
-    private PagedResult<AggregatedResult> buildAggregatedByColumn(final TransactionSearchQuery query) {
-        final SelectJoinStep<Record2<String, BigDecimal>> fromClause = this.dataSource
-                .select(
-                        Objects.requireNonNull(BankTransaction.BANK_TRANSACTION.field(query.aggregateByColumn())).cast(String.class),
-                        sum(BankTransaction.BANK_TRANSACTION.VALUE).as("total")
-                )
-                .from(BankTransaction.BANK_TRANSACTION);
-
-        SelectConditionStep<Record2<String, BigDecimal>> where = applyDateFilters(fromClause, query.from(), query.to());
-
-        Result<Record2<String, BigDecimal>> results = Objects.requireNonNullElse(where, fromClause)
-                .groupBy(BankTransaction.BANK_TRANSACTION.field(query.aggregateByColumn()))
-                .fetch();
-
-        List<AggregatedResult> records = results.stream()
-                .map(r -> new AggregatedResult(null, r.get(0, String.class), r.get("total", BigDecimal.class)))
-                .toList();
-
-        return new PagedResult<>(records, query.limit(), null);
-    }
-
-    private <R extends org.jooq.Record> SelectConditionStep<R> applyDateFilters(
-            SelectJoinStep<R> fromClause,
-            String from,
-            String to
-    ) {
-        SelectConditionStep<R> where = null;
-
-        if(from != null && !from.isEmpty()) {
-            where = fromClause.where(
-                    BankTransaction.BANK_TRANSACTION.DATE.greaterOrEqual(OffsetDateTime.parse(from))
-            );
-        }
-
-        if(to != null && !to.isEmpty()) {
-            if(where != null) {
-                where = where.and(BankTransaction.BANK_TRANSACTION.DATE.lessOrEqual(OffsetDateTime.parse(to)));
-            } else {
-                where = fromClause.where(
-                        BankTransaction.BANK_TRANSACTION.DATE.lessOrEqual(OffsetDateTime.parse(to))
-                );
-            }
-        }
-
-        return where;
+        return txQuery.searchAggregated(query);
     }
 
     @Override
@@ -272,7 +134,7 @@ public class TransactionStore extends Store implements TransactionRepository {
 
         String newCursor = null;
         boolean hasMoreRecords = !bankTransactionRecords.isEmpty() && bankTransactionRecords.size() >= sanitizedLimit + 1;
-        if ( hasMoreRecords ) {
+        if (hasMoreRecords) {
             BankTransactionRecord rec = bankTransactionRecords.removeLast();
             newCursor = Cursor.forId(rec.getId());
         }
@@ -294,215 +156,14 @@ public class TransactionStore extends Store implements TransactionRepository {
 
     @Override
     public FinancialRecord getById(UUID id) {
-        List<BankTransactionRecord> transactionRecord =  this.dataSource.selectFrom(BankTransaction.BANK_TRANSACTION)
+        List<BankTransactionRecord> transactionRecord = this.dataSource.selectFrom(BankTransaction.BANK_TRANSACTION)
                 .where(BankTransaction.BANK_TRANSACTION.UUID.eq(id))
                 .fetchInto(BankTransactionRecord.class);
 
-        if(transactionRecord.isEmpty()) {
+        if (transactionRecord.isEmpty()) {
             return null;
         }
 
         return toModel(transactionRecord.getFirst());
-    }
-
-    private String buildCursor(final Record record, final String aggregatedByColumn, final String aggregatedByPeriod){
-        final boolean hasGroupByColumn = aggregatedByColumn != null && !aggregatedByColumn.isEmpty();
-        final boolean hasGroupByPeriod = aggregatedByPeriod != null && !aggregatedByPeriod.isEmpty();
-
-        if (hasGroupByColumn && hasGroupByPeriod) {
-            return Cursor.forPeriodAndColumn(
-                    record.getValue("period", String.class),
-                    record.getValue(BankTransaction.BANK_TRANSACTION.CATEGORY));
-        }
-
-        if (hasGroupByPeriod) {
-            return Cursor.forPeriod(String.valueOf(record.getValue("period")));
-        }
-
-        if (hasGroupByColumn) {
-            return Cursor.forPeriod(String.valueOf(record.getValue(BankTransaction.BANK_TRANSACTION.CATEGORY)));
-        }
-
-        return Cursor.forPeriodAndColumn(
-                String.valueOf(record.getValue(BankTransaction.BANK_TRANSACTION.DATE)),
-                String.valueOf(record.getValue(BankTransaction.BANK_TRANSACTION.ID)));
-    }
-
-    // ========== Refactoring: Value Objects and Helper Classes ==========
-
-    enum AggregationPeriod {
-        YEAR("year", "YYYY"),
-        MONTH("month", "YYYY-MM");
-
-        private final String sqlTruncation;
-        private final String dateFormat;
-
-        AggregationPeriod(String sqlTruncation, String dateFormat) {
-            this.sqlTruncation = sqlTruncation;
-            this.dateFormat = dateFormat;
-        }
-
-        public String getSqlTruncation() {
-            return sqlTruncation;
-        }
-
-        public String getDateFormat() {
-            return dateFormat;
-        }
-
-        public static AggregationPeriod fromString(String period) {
-            if (period == null || period.isEmpty()) {
-                return null;
-            }
-            return period.equalsIgnoreCase("year") ? YEAR : MONTH;
-        }
-    }
-
-    record QueryContext(
-            DSLContext dsl,
-            TransactionSearchQuery query,
-            int sanitizedLimit,
-            int sanitizedCursor
-    ) {}
-
-    static class PaginationHandler {
-        String encodeCursor(String value) {
-            return Cursor.forId(Integer.parseInt(value));
-        }
-
-        <R extends Record> PagedResult<FinancialRecord> buildPagedResult(
-                Result<R> results,
-                int limit,
-                java.util.function.Function<R, FinancialRecord> mapper,
-                java.util.function.Function<R, String> cursorBuilder
-        ) {
-            String cursor = null;
-            boolean hasMore = results.size() > limit;
-
-            if (hasMore) {
-                R lastRecord = results.remove(results.size() - 1);
-                cursor = cursorBuilder.apply(lastRecord);
-            }
-
-            List<FinancialRecord> records = results.stream()
-                    .map(mapper)
-                    .collect(Collectors.toList());
-
-            return new PagedResult<>(records, limit, cursor);
-        }
-    }
-
-    static class QueryBuilderHelper {
-        private boolean hasValue(String s) {
-            return s != null && !s.isEmpty();
-        }
-
-        <R extends Record> SelectConditionStep<R> applyDateFilters(
-                SelectJoinStep<R> fromClause,
-                String from,
-                String to
-        ) {
-            SelectConditionStep<R> where = null;
-
-            if(from != null && !from.isEmpty()) {
-                where = fromClause.where(
-                        BankTransaction.BANK_TRANSACTION.DATE.greaterOrEqual(OffsetDateTime.parse(from))
-                );
-            }
-
-            if(to != null && !to.isEmpty()) {
-                if(where != null) {
-                    where = where.and(BankTransaction.BANK_TRANSACTION.DATE.lessOrEqual(OffsetDateTime.parse(to)));
-                } else {
-                    where = fromClause.where(
-                            BankTransaction.BANK_TRANSACTION.DATE.lessOrEqual(OffsetDateTime.parse(to))
-                    );
-                }
-            }
-
-            return where;
-        }
-
-        SelectConditionStep<BankTransactionRecord> applyCommonFilters(
-                SelectConditionStep<BankTransactionRecord> where,
-                TransactionSearchQuery searchQuery
-        ) {
-            if (hasValue(searchQuery.id())) {
-                where = where.and(BankTransaction.BANK_TRANSACTION.UUID.eq(UUID.fromString(searchQuery.id())));
-            }
-            if (hasValue(searchQuery.category())) {
-                where = where.and(BankTransaction.BANK_TRANSACTION.CATEGORY.eq(searchQuery.category()));
-            }
-            if (hasValue(searchQuery.bank())) {
-                where = where.and(BankTransaction.BANK_TRANSACTION.BANK_NAME.eq(searchQuery.bank()));
-            }
-            if (hasValue(searchQuery.from())) {
-                where = where.and(BankTransaction.BANK_TRANSACTION.DATE.greaterOrEqual(OffsetDateTime.parse(searchQuery.from())));
-            }
-            if (hasValue(searchQuery.to())) {
-                where = where.and(BankTransaction.BANK_TRANSACTION.DATE.lessOrEqual(OffsetDateTime.parse(searchQuery.to())));
-            }
-            if (searchQuery.excludeCategories() != null && !searchQuery.excludeCategories().isEmpty()) {
-                where = where.and(BankTransaction.BANK_TRANSACTION.CATEGORY.notIn(searchQuery.excludeCategories()));
-            }
-            return where;
-        }
-
-        List<SortField<?>> buildSortFields(String sort) {
-            if (sort != null && sort.equals("ASC")) {
-                return List.of(
-                        BankTransaction.BANK_TRANSACTION.DATE.asc(),
-                        BankTransaction.BANK_TRANSACTION.ID.asc()
-                );
-            }
-            return List.of(
-                    BankTransaction.BANK_TRANSACTION.DATE.desc(),
-                    BankTransaction.BANK_TRANSACTION.ID.desc()
-            );
-        }
-    }
-
-    interface TransactionQueryStrategy {
-        PagedResult<FinancialRecord> execute(QueryContext context);
-        boolean canHandle(TransactionSearchQuery query);
-    }
-
-    static class RegularSearchStrategy implements TransactionQueryStrategy {
-        private final QueryBuilderHelper queryBuilder;
-        private final PaginationHandler paginationHandler;
-
-        RegularSearchStrategy(QueryBuilderHelper queryBuilder, PaginationHandler paginationHandler) {
-            this.queryBuilder = queryBuilder;
-            this.paginationHandler = paginationHandler;
-        }
-
-        @Override
-        public boolean canHandle(TransactionSearchQuery query) {
-            boolean hasGroupByColumn = query.aggregateByColumn() != null && !query.aggregateByColumn().isEmpty();
-            boolean hasGroupByPeriod = query.aggregateByPeriod() != null && !query.aggregateByPeriod().isEmpty();
-            return !hasGroupByColumn && !hasGroupByPeriod;
-        }
-
-        @Override
-        public PagedResult<FinancialRecord> execute(QueryContext ctx) {
-            SelectConditionStep<BankTransactionRecord> where = ctx.dsl()
-                    .selectFrom(BankTransaction.BANK_TRANSACTION)
-                    .where(BankTransaction.BANK_TRANSACTION.ID.ge(ctx.sanitizedCursor()));
-
-            where = queryBuilder.applyCommonFilters(where, ctx.query());
-
-            List<SortField<?>> sortBy = queryBuilder.buildSortFields(ctx.query().sort());
-            Result<BankTransactionRecord> results = where
-                    .orderBy(sortBy)
-                    .limit(ctx.sanitizedLimit() + 1)
-                    .fetch();
-
-            return paginationHandler.buildPagedResult(
-                    results,
-                    ctx.sanitizedLimit(),
-                    TransactionStore::toModel,
-                    rec -> paginationHandler.encodeCursor(String.valueOf(rec.getId()))
-            );
-        }
     }
 }

--- a/app/src/test/java/com/moneymind/finance/infrastructure/postgres/TransactionQueryIntegrationTest.java
+++ b/app/src/test/java/com/moneymind/finance/infrastructure/postgres/TransactionQueryIntegrationTest.java
@@ -1,0 +1,261 @@
+package com.moneymind.finance.infrastructure.postgres;
+
+import com.moneymind.finance.domain.PagedResult;
+import com.moneymind.finance.domain.core.AggregatedResult;
+import com.moneymind.finance.domain.core.FinancialRecord;
+import com.moneymind.finance.domain.core.TransactionSearchQuery;
+import com.moneymind.persistence.PersistenceHarness;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TransactionQueryIntegrationTest extends PersistenceHarness {
+
+    private TransactionQuery txQuery;
+
+    private static final OffsetDateTime JAN = OffsetDateTime.parse("2024-01-15T12:00:00Z");
+    private static final OffsetDateTime FEB = OffsetDateTime.parse("2024-02-15T12:00:00Z");
+    private static final OffsetDateTime MAR = OffsetDateTime.parse("2024-03-15T12:00:00Z");
+
+    @BeforeEach
+    void init() {
+        txQuery = new TransactionQuery(dsl);
+    }
+
+    // ─── search ──────────────────────────────────────────────────────────────
+
+    @Test
+    void search_returnsAllRows_whenNoFilters() {
+        seedTransaction(bd("10"), bd("100"), "tx1", "BANK_A", JAN, "Food");
+        seedTransaction(bd("20"), bd("200"), "tx2", "BANK_B", FEB, "Transport");
+
+        PagedResult<FinancialRecord> result = txQuery.search(query().build());
+
+        assertEquals(2, result.list().size());
+    }
+
+    @Test
+    void search_categoryFilter_returnsOnlyMatchingRows() {
+        seedTransaction(bd("10"), bd("100"), "food tx", "BANK_A", JAN, "Food");
+        seedTransaction(bd("20"), bd("200"), "transport tx", "BANK_B", FEB, "Transport");
+
+        PagedResult<FinancialRecord> result = txQuery.search(query().category("Food").build());
+
+        assertEquals(1, result.list().size());
+        assertEquals("Food", result.list().getFirst().getCategory());
+    }
+
+    @Test
+    void search_bankFilter_returnsOnlyMatchingRows() {
+        seedTransaction(bd("10"), bd("100"), "tx1", "BANK_A", JAN, "Food");
+        seedTransaction(bd("20"), bd("200"), "tx2", "BANK_B", FEB, "Food");
+
+        PagedResult<FinancialRecord> result = txQuery.search(query().bank("BANK_A").build());
+
+        assertEquals(1, result.list().size());
+        assertEquals("BANK_A", result.list().getFirst().getBankName());
+    }
+
+    @Test
+    void search_fromDateFilter_excludesEarlierRows() {
+        seedTransaction(bd("10"), bd("100"), "old", "BANK_A", JAN, "Food");
+        seedTransaction(bd("20"), bd("200"), "new", "BANK_A", MAR, "Food");
+
+        PagedResult<FinancialRecord> result = txQuery.search(
+                query().from("2024-02-01T00:00:00Z").build());
+
+        assertEquals(1, result.list().size());
+        assertEquals("new", result.list().getFirst().getDescription());
+    }
+
+    @Test
+    void search_toDateFilter_excludesLaterRows() {
+        seedTransaction(bd("10"), bd("100"), "old", "BANK_A", JAN, "Food");
+        seedTransaction(bd("20"), bd("200"), "new", "BANK_A", MAR, "Food");
+
+        PagedResult<FinancialRecord> result = txQuery.search(
+                query().to("2024-02-01T00:00:00Z").build());
+
+        assertEquals(1, result.list().size());
+        assertEquals("old", result.list().getFirst().getDescription());
+    }
+
+    @Test
+    void search_excludeCategories_omitsMatchingRows() {
+        seedTransaction(bd("10"), bd("100"), "food tx", "BANK_A", JAN, "Food");
+        seedTransaction(bd("20"), bd("200"), "excluded tx", "BANK_A", FEB, "Excluded");
+
+        PagedResult<FinancialRecord> result = txQuery.search(
+                query().excludeCategories(List.of("Excluded")).build());
+
+        assertEquals(1, result.list().size());
+        assertEquals("Food", result.list().getFirst().getCategory());
+    }
+
+    @Test
+    void search_pagination_cursorAdvancesToNextPage() {
+        seedTransaction(bd("10"), bd("100"), "tx1", "BANK_A", MAR, "Food");
+        seedTransaction(bd("20"), bd("200"), "tx2", "BANK_A", FEB, "Food");
+        seedTransaction(bd("30"), bd("300"), "tx3", "BANK_A", JAN, "Food");
+
+        PagedResult<FinancialRecord> page1 = txQuery.search(query().limit(2).build());
+        assertEquals(2, page1.list().size());
+        assertNotNull(page1.cursor(), "cursor should point to page 2");
+
+        PagedResult<FinancialRecord> page2 = txQuery.search(query().limit(2).cursor(page1.cursor()).build());
+        assertEquals(1, page2.list().size());
+        assertNull(page2.cursor(), "no further pages");
+    }
+
+    @Test
+    void search_ascSort_returnsOldestFirst() {
+        seedTransaction(bd("10"), bd("100"), "old", "BANK_A", JAN, "Food");
+        seedTransaction(bd("20"), bd("200"), "new", "BANK_A", MAR, "Food");
+
+        PagedResult<FinancialRecord> result = txQuery.search(query().sort("ASC").build());
+
+        assertEquals("old", result.list().getFirst().getDescription());
+        assertEquals("new", result.list().getLast().getDescription());
+    }
+
+    // ─── aggregate by period ─────────────────────────────────────────────────
+
+    @Test
+    void searchAggregated_byMonth_groupsCorrectly() {
+        seedTransaction(bd("100"), bd("1000"), "jan tx", "BANK_A", JAN, null);
+        seedTransaction(bd("50"), bd("950"), "jan tx2", "BANK_A", JAN, null);
+        seedTransaction(bd("200"), bd("1200"), "feb tx", "BANK_A", FEB, null);
+
+        PagedResult<AggregatedResult> result = txQuery.searchAggregated(
+                query().aggregateByPeriod("month").build());
+
+        assertEquals(2, result.list().size());
+        AggregatedResult jan = result.list().stream()
+                .filter(r -> "2024-01".equals(r.period())).findFirst().orElseThrow();
+        assertEquals(0, new BigDecimal("150").compareTo(jan.total()));
+        assertNull(jan.groupKey());
+    }
+
+    @Test
+    void searchAggregated_byYear_groupsCorrectly() {
+        seedTransaction(bd("100"), bd("1000"), "tx1", "BANK_A", JAN, null);
+        seedTransaction(bd("200"), bd("1200"), "tx2", "BANK_A", MAR, null);
+
+        PagedResult<AggregatedResult> result = txQuery.searchAggregated(
+                query().aggregateByPeriod("year").build());
+
+        assertEquals(1, result.list().size());
+        assertEquals("2024", result.list().getFirst().period());
+        assertEquals(0, new BigDecimal("300").compareTo(result.list().getFirst().total()));
+    }
+
+    @Test
+    void searchAggregated_byPeriod_cursorNonNullWhenMoreResults() {
+        seedTransaction(bd("100"), bd("1000"), "jan", "BANK_A", JAN, null);
+        seedTransaction(bd("200"), bd("1200"), "feb", "BANK_A", FEB, null);
+        seedTransaction(bd("300"), bd("1500"), "mar", "BANK_A", MAR, null);
+
+        PagedResult<AggregatedResult> result = txQuery.searchAggregated(
+                query().aggregateByPeriod("month").limit(2).build());
+
+        assertEquals(2, result.list().size());
+        assertNotNull(result.cursor(), "cursor indicates more results exist");
+    }
+
+    @Test
+    void searchAggregated_byPeriod_cursorNullWhenAllResultsFit() {
+        seedTransaction(bd("100"), bd("1000"), "jan", "BANK_A", JAN, null);
+        seedTransaction(bd("200"), bd("1200"), "feb", "BANK_A", FEB, null);
+
+        PagedResult<AggregatedResult> result = txQuery.searchAggregated(
+                query().aggregateByPeriod("month").limit(10).build());
+
+        assertEquals(2, result.list().size());
+        assertNull(result.cursor());
+    }
+
+    @Test
+    void searchAggregated_byPeriod_dateRangeFilter_honoured() {
+        seedTransaction(bd("100"), bd("1000"), "jan", "BANK_A", JAN, null);
+        seedTransaction(bd("200"), bd("1200"), "mar", "BANK_A", MAR, null);
+
+        PagedResult<AggregatedResult> result = txQuery.searchAggregated(
+                query().aggregateByPeriod("month")
+                        .from("2024-02-01T00:00:00Z")
+                        .build());
+
+        assertEquals(1, result.list().size());
+        assertEquals("2024-03", result.list().getFirst().period());
+    }
+
+    // ─── aggregate by column ─────────────────────────────────────────────────
+
+    @Test
+    void searchAggregated_byColumn_groupsByCategory() {
+        seedTransaction(bd("100"), bd("1000"), "food1", "BANK_A", JAN, "Food");
+        seedTransaction(bd("50"), bd("950"), "food2", "BANK_A", FEB, "Food");
+        seedTransaction(bd("200"), bd("1200"), "transport", "BANK_A", MAR, "Transport");
+
+        PagedResult<AggregatedResult> result = txQuery.searchAggregated(
+                query().aggregateByColumn("category").build());
+
+        assertEquals(2, result.list().size());
+        AggregatedResult food = result.list().stream()
+                .filter(r -> "Food".equals(r.groupKey())).findFirst().orElseThrow();
+        assertEquals(0, new BigDecimal("150").compareTo(food.total()));
+        assertNull(food.period());
+    }
+
+    @Test
+    void searchAggregated_byColumn_returnsCursorNull() {
+        seedTransaction(bd("100"), bd("1000"), "tx", "BANK_A", JAN, "Food");
+
+        PagedResult<AggregatedResult> result = txQuery.searchAggregated(
+                query().aggregateByColumn("category").build());
+
+        assertNull(result.cursor(), "aggregate-by-column never returns a cursor");
+    }
+
+    // ─── aggregate by period + column ────────────────────────────────────────
+
+    @Test
+    void searchAggregated_byPeriodAndColumn_groupsByBoth() {
+        seedTransaction(bd("100"), bd("1000"), "jan food", "BANK_A", JAN, "Food");
+        seedTransaction(bd("50"), bd("950"), "jan transport", "BANK_A", JAN, "Transport");
+        seedTransaction(bd("200"), bd("1200"), "feb food", "BANK_A", FEB, "Food");
+
+        PagedResult<AggregatedResult> result = txQuery.searchAggregated(
+                query().aggregateByPeriod("month").aggregateByColumn("category").build());
+
+        assertEquals(3, result.list().size());
+        AggregatedResult janFood = result.list().stream()
+                .filter(r -> "2024-01".equals(r.period()) && "Food".equals(r.groupKey()))
+                .findFirst().orElseThrow();
+        assertEquals(0, new BigDecimal("100").compareTo(janFood.total()));
+    }
+
+    @Test
+    void searchAggregated_byPeriodAndColumn_returnsCursorNull() {
+        seedTransaction(bd("100"), bd("1000"), "tx", "BANK_A", JAN, "Food");
+
+        PagedResult<AggregatedResult> result = txQuery.searchAggregated(
+                query().aggregateByPeriod("month").aggregateByColumn("category").build());
+
+        assertNull(result.cursor(), "aggregate-by-period+column never returns a cursor");
+    }
+
+    // ─── helpers ─────────────────────────────────────────────────────────────
+
+    private static TransactionSearchQuery.Builder query() {
+        return TransactionSearchQuery.builder().limit(10);
+    }
+
+    private static BigDecimal bd(String val) {
+        return new BigDecimal(val);
+    }
+}

--- a/app/src/test/java/com/moneymind/finance/infrastructure/postgres/TransactionQuerySqlTest.java
+++ b/app/src/test/java/com/moneymind/finance/infrastructure/postgres/TransactionQuerySqlTest.java
@@ -1,0 +1,208 @@
+package com.moneymind.finance.infrastructure.postgres;
+
+import com.moneymind.finance.domain.core.TransactionSearchQuery;
+import org.jooq.DSLContext;
+import org.jooq.Select;
+import org.jooq.SQLDialect;
+import org.jooq.conf.ParamType;
+import org.jooq.impl.DSL;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Rendered-SQL tests: assert the SQL jOOQ builds for each query shape
+ * and filter without touching a real database.
+ */
+class TransactionQuerySqlTest {
+
+    private TransactionQuery txQuery;
+
+    @BeforeEach
+    void setUp() {
+        DSLContext dsl = DSL.using(SQLDialect.POSTGRES);
+        txQuery = new TransactionQuery(dsl);
+    }
+
+    // ─── regular search ───────────────────────────────────────────────────────
+
+    @Test
+    void search_baseQuery_selectsFromBankTransaction() {
+        String sql = sql(txQuery.buildSearchSelect(query().build()));
+        assertContains(sql, "bank_transaction");
+    }
+
+    @Test
+    void search_defaultSort_ordersByDateDescIdDesc() {
+        String sql = sql(txQuery.buildSearchSelect(query().build()));
+        assertContains(sql, "order by");
+        assertContains(sql, "\"date\" desc");
+        assertContains(sql, "\"id\" desc");
+    }
+
+    @Test
+    void search_ascSort_ordersByDateAscIdAsc() {
+        String sql = sql(txQuery.buildSearchSelect(query().sort("ASC").build()));
+        assertContains(sql, "\"date\" asc");
+        assertContains(sql, "\"id\" asc");
+    }
+
+    @Test
+    void search_limitIsAppliedPlusOne() {
+        String sql = sql(txQuery.buildSearchSelect(query().limit(5).build()));
+        assertContains(sql, "fetch next 6 rows only");
+    }
+
+    @Test
+    void search_categoryFilter_addsCategoryCondition() {
+        String sql = sql(txQuery.buildSearchSelect(query().category("Food").build()));
+        assertContains(sql, "\"category\" = 'food'");
+    }
+
+    @Test
+    void search_bankFilter_addsBankCondition() {
+        String sql = sql(txQuery.buildSearchSelect(query().bank("MY_BANK").build()));
+        assertContains(sql, "\"bank_name\" = 'my_bank'");
+    }
+
+    @Test
+    void search_idFilter_addsUuidCondition() {
+        String uuid = "00000000-0000-0000-0000-000000000001";
+        String sql = sql(txQuery.buildSearchSelect(query().id(uuid).build()));
+        assertContains(sql, uuid.toLowerCase());
+    }
+
+    @Test
+    void search_fromDateFilter_addsGreaterOrEqualCondition() {
+        String sql = sql(txQuery.buildSearchSelect(query().from("2024-01-01T00:00:00Z").build()));
+        assertContains(sql, "\"date\" >= ");
+        assertContains(sql, "2024-01-01");
+    }
+
+    @Test
+    void search_toDateFilter_addsLessOrEqualCondition() {
+        String sql = sql(txQuery.buildSearchSelect(query().to("2024-12-31T23:59:59Z").build()));
+        assertContains(sql, "\"date\" <= ");
+        assertContains(sql, "2024-12-31");
+    }
+
+    @Test
+    void search_dateRange_appliesBothConditions() {
+        String sql = sql(txQuery.buildSearchSelect(
+                query().from("2024-01-01T00:00:00Z").to("2024-12-31T23:59:59Z").build()));
+        assertContains(sql, "\"date\" >= ");
+        assertContains(sql, "\"date\" <= ");
+    }
+
+    @Test
+    void search_excludeCategories_addsNotInCondition() {
+        String sql = sql(txQuery.buildSearchSelect(
+                query().excludeCategories(List.of("Excluded", "Hidden")).build()));
+        assertContains(sql, "not in");
+        assertContains(sql, "'excluded'");
+        assertContains(sql, "'hidden'");
+    }
+
+    // ─── aggregate by period ─────────────────────────────────────────────────
+
+    @Test
+    void byPeriod_month_usesTruncMonth() {
+        String sql = sql(txQuery.buildByPeriodSelect(query().aggregateByPeriod("month").build()));
+        assertContains(sql, "date_trunc('month'");
+        assertContains(sql, "yyyy-mm");
+        assertContains(sql, "group by");
+    }
+
+    @Test
+    void byPeriod_year_usesTruncYear() {
+        String sql = sql(txQuery.buildByPeriodSelect(query().aggregateByPeriod("year").build()));
+        assertContains(sql, "date_trunc('year'");
+        assertContains(sql, "yyyy");
+        assertContains(sql, "group by");
+    }
+
+    @Test
+    void byPeriod_limitIsAppliedPlusOne() {
+        String sql = sql(txQuery.buildByPeriodSelect(query().aggregateByPeriod("month").limit(3).build()));
+        assertContains(sql, "fetch next 4 rows only");
+    }
+
+    @Test
+    void byPeriod_dateRangeFilter_appliesBothConditions() {
+        String sql = sql(txQuery.buildByPeriodSelect(
+                query().aggregateByPeriod("month")
+                        .from("2024-01-01T00:00:00Z")
+                        .to("2024-06-30T23:59:59Z")
+                        .build()));
+        assertContains(sql, "\"date\" >= ");
+        assertContains(sql, "\"date\" <= ");
+    }
+
+    // ─── aggregate by column ─────────────────────────────────────────────────
+
+    @Test
+    void byColumn_groupsByRequestedColumn() {
+        String sql = sql(txQuery.buildByColumnSelect(query().aggregateByColumn("category").build()));
+        assertContains(sql, "\"category\"");
+        assertContains(sql, "group by");
+    }
+
+    @Test
+    void byColumn_dateRangeFilter_appliesBothConditions() {
+        String sql = sql(txQuery.buildByColumnSelect(
+                query().aggregateByColumn("category")
+                        .from("2024-01-01T00:00:00Z")
+                        .to("2024-12-31T23:59:59Z")
+                        .build()));
+        assertContains(sql, "\"date\" >= ");
+        assertContains(sql, "\"date\" <= ");
+    }
+
+    // ─── aggregate by period + column ────────────────────────────────────────
+
+    @Test
+    void byPeriodAndColumn_groupsByPeriodAndCategory() {
+        String sql = sql(txQuery.buildByPeriodAndColumnSelect(
+                query().aggregateByPeriod("month").aggregateByColumn("category").build()));
+        assertContains(sql, "date_trunc('month'");
+        assertContains(sql, "yyyy-mm");
+        assertContains(sql, "group by");
+        assertContains(sql, "\"category\"");
+    }
+
+    @Test
+    void byPeriodAndColumn_limitIsAppliedPlusOne() {
+        String sql = sql(txQuery.buildByPeriodAndColumnSelect(
+                query().aggregateByPeriod("month").aggregateByColumn("category").limit(2).build()));
+        assertContains(sql, "fetch next 3 rows only");
+    }
+
+    @Test
+    void byPeriodAndColumn_dateRangeFilter_appliesBothConditions() {
+        String sql = sql(txQuery.buildByPeriodAndColumnSelect(
+                query().aggregateByPeriod("month").aggregateByColumn("category")
+                        .from("2024-01-01T00:00:00Z")
+                        .to("2024-06-30T23:59:59Z")
+                        .build()));
+        assertContains(sql, "\"date\" >= ");
+        assertContains(sql, "\"date\" <= ");
+    }
+
+    // ─── helpers ─────────────────────────────────────────────────────────────
+
+    private static TransactionSearchQuery.Builder query() {
+        return TransactionSearchQuery.builder().limit(10);
+    }
+
+    private static String sql(Select<?> select) {
+        return select.getSQL(ParamType.INLINED).toLowerCase();
+    }
+
+    private static void assertContains(String sql, String fragment) {
+        assertTrue(sql.contains(fragment.toLowerCase()),
+                "Expected SQL to contain: " + fragment + "\nActual SQL: " + sql);
+    }
+}

--- a/app/src/test/java/com/moneymind/persistence/PersistenceHarness.java
+++ b/app/src/test/java/com/moneymind/persistence/PersistenceHarness.java
@@ -10,7 +10,7 @@ import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 
 @Tag("integration")
-abstract class PersistenceHarness {
+public abstract class PersistenceHarness {
 
     protected static final DSLContext dsl = PostgresTestContainer.DSL_CTX;
 

--- a/app/src/test/java/com/moneymind/persistence/PostgresTestContainer.java
+++ b/app/src/test/java/com/moneymind/persistence/PostgresTestContainer.java
@@ -10,9 +10,9 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 
-final class PostgresTestContainer {
+public final class PostgresTestContainer {
 
-    static final DSLContext DSL_CTX;
+    public static final DSLContext DSL_CTX;
 
     private static final PostgreSQLContainer<?> POSTGRES;
 


### PR DESCRIPTION
Introduces TransactionQuery as the single deep module owning all query-side logic for the finance postgres adapter.

Key decisions:
- AggregationPeriod promoted to finance/domain/core/ as the single source of truth for period→SQL truncation/date-format mapping
- TransactionQuery exposes 4 package-private build* methods (one per query shape) so rendered-SQL tests can assert jOOQ output without a database; public search/searchAggregated call these then execute
- Dead strategy seam (TransactionQueryStrategy, QueryContext, RegularSearchStrategy, canHandle, buildAggregatedBy*) removed from TransactionStore; search/searchAggregated are now one-liner delegates
- applyDateFilters consolidated to a single definition in TransactionQuery
- All cursor encoding routes through Cursor from domain/core
- PersistenceHarness and PostgresTestContainer made public so integration tests in the postgres infrastructure package can reuse them

Files changed:
- NEW: finance/domain/core/AggregationPeriod.java
- NEW: finance/infrastructure/postgres/TransactionQuery.java
- MOD: finance/infrastructure/postgres/TransactionStore.java
- MOD: test/persistence/PersistenceHarness.java (public)
- MOD: test/persistence/PostgresTestContainer.java (public + public field)
- NEW: test/finance/infrastructure/postgres/TransactionQuerySqlTest.java
- NEW: test/finance/infrastructure/postgres/TransactionQueryIntegrationTest.java

41 tests pass (20 SQL + 21 integration, + 13 pre-existing unit tests). Pagination quirk preserved: byColumn and byPeriodAndColumn return null cursor. fetchNoCategoriesTransaction stays inline in TransactionStore (issue 0004).