### PR TITLE
RALPH: SearchTransactions routing, ExportTransactions, GetTransaction…

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,81 @@
+# Finance
+
+The MoneyMind backend bounded context: it ingests bank transaction files, classifies each transaction into a category, persists them, and serves search, aggregation, and review over them. Hexagonal architecture — domain owns the ports, infrastructure provides the adapters.
+
+## Language
+
+### Core records
+
+**FinancialRecord**:
+A single persisted bank transaction — id, bank, date, description, amount, balance, category.
+_Avoid_: transaction (ambiguous with the classifier's own `Transaction` type), entry, row.
+
+**ClassifiedFinancialRecord**:
+A `FinancialRecord` paired with a predicted category and a confidence score, produced by classification.
+_Avoid_: prediction, result.
+
+**AggregatedResult**:
+A grouped, summed row: an optional `period`, an optional `groupKey` (column value), and a `total`.
+_Avoid_: summary (reserved for the guest-review `Summary`), group, bucket.
+
+### Search & pagination
+
+**TransactionSearchQuery**:
+The parameter object carrying every search input — filters (id, category, bank, date range, excludeCategories), `aggregateByPeriod` / `aggregateByColumn`, sort, limit, cursor.
+_Avoid_: filter, criteria, params, request.
+
+**TransactionQuery**:
+The deep module that builds and executes every query shape from a `TransactionSearchQuery`, exposing `search` (→ `PagedResult<FinancialRecord>`) and `searchAggregated` (→ `PagedResult<AggregatedResult>`). Owns filters, sort, period truncation, and pagination.
+_Avoid_: query builder, strategy, helper, repository (the repository is a separate port it sits behind).
+
+**SearchResult**:
+A sealed type expressing the outcome of `SearchTransactions.execute()`: either `Records(PagedResult<FinancialRecord>)` (regular transactions) or `Aggregated(PagedResult<AggregatedResult>)` (grouped rows). The thing the web layer pattern-matches on to choose a response envelope.
+_Avoid_: response, either, union.
+
+**PagedResult**:
+A page of items plus the effective `limit` and the next `cursor` (null when no further page).
+_Avoid_: page (reserved for the HTTP `Page` envelope), slice.
+
+**Cursor**:
+The opaque pagination token. One module owns its format and its encode/decode for every variant (single id; period; period + column).
+_Avoid_: offset, token, page key, bookmark.
+
+**AggregationPeriod**:
+The time granularity of a period aggregation — `YEAR` or `MONTH` — and the single source mapping each to its SQL truncation and date format.
+_Avoid_: bare "period" (that's the resulting label on an `AggregatedResult`), granularity, interval.
+
+### Classification & categories
+
+**TransactionClassifier**:
+The domain port that classifies records into categories. Its single live method takes a list of `FinancialRecord` and returns `ClassifiedFinancialRecord`s.
+_Avoid_: predictor, ML service.
+
+**Category / Subcategory**:
+A category tree: top-level Categories contain Subcategories. System categories are global (`user_id` null).
+_Avoid_: tag, label, bucket.
+
+**CategoryType**:
+The role a category plays in a summary — `INCOME`, `EXPENSE`, or `EXCLUDED`.
+_Avoid_: kind, classification.
+
+### Guest review
+
+**GuestImport**:
+The stateless use case that parses an uploaded file in memory, classifies it, and produces a `GuestReview` — deliberately with no persistence and no `TransactionRepository`.
+_Avoid_: trial import, preview.
+
+**GuestReview / MonthlyReview**:
+The result of a guest import: the detected bank plus one `MonthlyReview` per month (income, expense, savings, category slices).
+_Avoid_: report, snapshot.
+
+### Summary
+
+**SummaryEngine / Summary**:
+The pure module (and its result) computing income, expense, savings, and per-category/subcategory breakdowns from a list of summary transactions.
+_Avoid_: aggregator, calculator, stats.
+
+### Banks
+
+**BankRegistry / TransactionsParser**:
+The port that lists available banks and yields a `TransactionsParser` per bank; each parser turns a bank's CSV/XLS into `FinancialRecord`s.
+_Avoid_: importer, reader, loader.

--- a/app/src/main/java/com/moneymind/finance/di/DI.java
+++ b/app/src/main/java/com/moneymind/finance/di/DI.java
@@ -11,6 +11,7 @@ import com.moneymind.finance.domain.ports.TransactionClassifier;
 import com.moneymind.finance.domain.ports.TransactionRepository;
 import com.moneymind.finance.domain.ports.TransactionsParser;
 import com.moneymind.finance.domain.transactions.ClassifyTransactions;
+import com.moneymind.finance.domain.transactions.ExportTransactions;
 import com.moneymind.finance.domain.transactions.GetTransaction;
 import com.moneymind.finance.domain.transactions.ImportTransactions;
 import com.moneymind.finance.domain.transactions.SearchTransactions;
@@ -71,6 +72,12 @@ public class DI {
     @Produces
     SearchTransactions searchTransactions(final TransactionRepository transactionRepository) {
         return new SearchTransactions(transactionRepository);
+    }
+
+    @ApplicationScoped
+    @Produces
+    ExportTransactions exportTransactions(final TransactionRepository transactionRepository) {
+        return new ExportTransactions(transactionRepository);
     }
 
     @ApplicationScoped

--- a/app/src/main/java/com/moneymind/finance/domain/core/SearchResult.java
+++ b/app/src/main/java/com/moneymind/finance/domain/core/SearchResult.java
@@ -1,0 +1,10 @@
+package com.moneymind.finance.domain.core;
+
+import com.moneymind.finance.domain.PagedResult;
+
+public sealed interface SearchResult permits SearchResult.Records, SearchResult.Aggregated {
+
+    record Records(PagedResult<FinancialRecord> result) implements SearchResult {}
+
+    record Aggregated(PagedResult<AggregatedResult> result) implements SearchResult {}
+}

--- a/app/src/main/java/com/moneymind/finance/domain/transactions/ExportTransactions.java
+++ b/app/src/main/java/com/moneymind/finance/domain/transactions/ExportTransactions.java
@@ -1,0 +1,47 @@
+package com.moneymind.finance.domain.transactions;
+
+import com.moneymind.finance.domain.core.FinancialRecord;
+import com.moneymind.finance.domain.core.TransactionSearchQuery;
+import com.moneymind.finance.domain.ports.TransactionRepository;
+import com.opencsv.CSVWriter;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.List;
+
+public class ExportTransactions {
+
+    private final TransactionRepository transactionRepository;
+
+    public ExportTransactions(final TransactionRepository transactionRepository) {
+        this.transactionRepository = transactionRepository;
+    }
+
+    public String execute() {
+        TransactionSearchQuery query = TransactionSearchQuery.builder()
+                .limit(10000)
+                .build();
+
+        List<FinancialRecord> records = transactionRepository.search(query).list();
+
+        StringWriter stringWriter = new StringWriter();
+        try (CSVWriter csvWriter = new CSVWriter(stringWriter)) {
+            csvWriter.writeNext(new String[]{"ID", "Bank", "Date", "Description", "Amount", "Balance", "Category"});
+            for (FinancialRecord record : records) {
+                csvWriter.writeNext(new String[]{
+                        record.getId(),
+                        record.getBankName(),
+                        record.getDate() != null ? record.getDate().toString() : "",
+                        record.getDescription(),
+                        record.getAmount() != null ? record.getAmount().toString() : "",
+                        record.getFinalBalance() != null ? record.getFinalBalance().toString() : "",
+                        record.getCategory()
+                });
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Error generating CSV", e);
+        }
+
+        return stringWriter.toString();
+    }
+}

--- a/app/src/main/java/com/moneymind/finance/domain/transactions/GetTransaction.java
+++ b/app/src/main/java/com/moneymind/finance/domain/transactions/GetTransaction.java
@@ -14,6 +14,10 @@ public class GetTransaction {
     }
 
     public FinancialRecord execute(String id) {
-        return this.transactionRepository.getById(UUID.fromString(id));
+        try {
+            return transactionRepository.getById(UUID.fromString(id));
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
     }
 }

--- a/app/src/main/java/com/moneymind/finance/domain/transactions/SearchTransactions.java
+++ b/app/src/main/java/com/moneymind/finance/domain/transactions/SearchTransactions.java
@@ -1,26 +1,25 @@
 package com.moneymind.finance.domain.transactions;
 
-import com.moneymind.finance.domain.PagedResult;
-import com.moneymind.finance.domain.core.AggregatedResult;
-import com.moneymind.finance.domain.core.FinancialRecord;
+import com.moneymind.finance.domain.core.SearchResult;
 import com.moneymind.finance.domain.core.TransactionSearchQuery;
 import com.moneymind.finance.domain.ports.TransactionRepository;
-import org.jboss.logging.Logger;
 
 
 public class SearchTransactions {
-    private final Logger LOG = Logger.getLogger(SearchTransactions.class);
+
     private final TransactionRepository transactionRepository;
 
     public SearchTransactions(final TransactionRepository transactionRepository) {
         this.transactionRepository = transactionRepository;
     }
 
-    public PagedResult<FinancialRecord> execute(TransactionSearchQuery query) {
-        return this.transactionRepository.search(query);
-    }
+    public SearchResult execute(TransactionSearchQuery query) {
+        boolean isAggregating = (query.aggregateByPeriod() != null && !query.aggregateByPeriod().isEmpty())
+                || (query.aggregateByColumn() != null && !query.aggregateByColumn().isEmpty());
 
-    public PagedResult<AggregatedResult> executeAggregated(TransactionSearchQuery query) {
-        return this.transactionRepository.searchAggregated(query);
+        if (isAggregating) {
+            return new SearchResult.Aggregated(transactionRepository.searchAggregated(query));
+        }
+        return new SearchResult.Records(transactionRepository.search(query));
     }
 }

--- a/app/src/main/java/com/moneymind/finance/infrastructure/web/http/TransactionsResource.java
+++ b/app/src/main/java/com/moneymind/finance/infrastructure/web/http/TransactionsResource.java
@@ -1,17 +1,16 @@
 package com.moneymind.finance.infrastructure.web.http;
 
-import com.moneymind.finance.domain.PagedResult;
-import com.moneymind.finance.domain.core.AggregatedResult;
 import com.moneymind.finance.domain.core.ClassifiedFinancialRecord;
 import com.moneymind.finance.domain.core.FinancialRecord;
+import com.moneymind.finance.domain.core.SearchResult;
 import com.moneymind.finance.domain.core.TransactionSearchQuery;
+import com.moneymind.finance.domain.transactions.ExportTransactions;
 import com.moneymind.finance.domain.transactions.GetTransaction;
 import com.moneymind.finance.domain.transactions.ImportTransactions;
 import com.moneymind.finance.domain.transactions.SearchTransactions;
 import com.moneymind.finance.domain.transactions.UpdateTransactions;
 import com.moneymind.finance.infrastructure.web.http.dto.UpdateCategoryRequest;
 import com.moneymind.finance.infrastructure.web.http.hateoas.Link;
-import com.opencsv.CSVWriter;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
@@ -19,9 +18,7 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 import org.jboss.resteasy.reactive.RestForm;
 
-import java.io.IOException;
 import java.io.InputStream;
-import java.io.StringWriter;
 import java.util.List;
 
 @Path("/transactions")
@@ -29,13 +26,16 @@ public class TransactionsResource {
 
     private final ImportTransactions importTransactions;
     private final SearchTransactions searchTransactions;
+    private final ExportTransactions exportTransactions;
     private final UpdateTransactions updateTransactions;
     private final GetTransaction getTransaction;
 
     public TransactionsResource(ImportTransactions importTransactions, SearchTransactions searchTransactions,
-                                UpdateTransactions updateTransactions, GetTransaction getTransaction) {
+                                ExportTransactions exportTransactions, UpdateTransactions updateTransactions,
+                                GetTransaction getTransaction) {
         this.importTransactions = importTransactions;
         this.searchTransactions = searchTransactions;
+        this.exportTransactions = exportTransactions;
         this.updateTransactions = updateTransactions;
         this.getTransaction = getTransaction;
     }
@@ -84,16 +84,12 @@ public class TransactionsResource {
                 .sort(sort)
                 .build();
 
-        boolean isAggregating = (aggregateByPeriod != null && !aggregateByPeriod.isEmpty())
-                || (aggregateByColumn != null && !aggregateByColumn.isEmpty());
+        SearchResult result = this.searchTransactions.execute(query);
 
-        if (isAggregating) {
-            PagedResult<AggregatedResult> result = this.searchTransactions.executeAggregated(query);
-            return Response.ok(new Page<>(Link.buildNextLink(result, uriInfo), result.list())).build();
-        }
-
-        PagedResult<FinancialRecord> result = this.searchTransactions.execute(query);
-        return Response.ok(new Page<>(Link.buildNextLink(result, uriInfo), result.list())).build();
+        return switch (result) {
+            case SearchResult.Records r -> Response.ok(new Page<>(Link.buildNextLink(r.result(), uriInfo), r.result().list())).build();
+            case SearchResult.Aggregated a -> Response.ok(new Page<>(Link.buildNextLink(a.result(), uriInfo), a.result().list())).build();
+        };
     }
 
     @GET
@@ -122,31 +118,8 @@ public class TransactionsResource {
     @GET
     @Path("/export")
     public Response exportTransactions() {
-        TransactionSearchQuery query = TransactionSearchQuery.builder()
-                .limit(10000)
-                .build();
-
-        List<FinancialRecord> transactions = this.searchTransactions.execute(query).list();
-
-        StringWriter stringWriter = new StringWriter();
-        try (CSVWriter csvWriter = new CSVWriter(stringWriter)) {
-            csvWriter.writeNext(new String[]{"ID", "Bank", "Date", "Description", "Amount", "Balance", "Category"});
-            for (FinancialRecord record : transactions) {
-                csvWriter.writeNext(new String[]{
-                        record.getId(),
-                        record.getBankName(),
-                        record.getDate() != null ? record.getDate().toString() : "",
-                        record.getDescription(),
-                        record.getAmount() != null ? record.getAmount().toString() : "",
-                        record.getFinalBalance() != null ? record.getFinalBalance().toString() : "",
-                        record.getCategory()
-                });
-            }
-        } catch (IOException e) {
-            return Response.serverError().entity("Error generating CSV: " + e.getMessage()).build();
-        }
-
-        return Response.ok(stringWriter.toString())
+        String csv = this.exportTransactions.execute();
+        return Response.ok(csv)
                 .header("Content-Disposition", "attachment; filename=\"transactions.csv\"")
                 .type("text/csv")
                 .build();

--- a/app/src/test/java/com/moneymind/domain/transactions/ExportTransactionsTest.java
+++ b/app/src/test/java/com/moneymind/domain/transactions/ExportTransactionsTest.java
@@ -1,0 +1,92 @@
+package com.moneymind.domain.transactions;
+
+import com.moneymind.FinancialRecordTestFactory;
+import com.moneymind.finance.domain.PagedResult;
+import com.moneymind.finance.domain.core.FinancialRecord;
+import com.moneymind.finance.domain.core.TransactionSearchQuery;
+import com.moneymind.finance.domain.ports.TransactionRepository;
+import com.moneymind.finance.domain.transactions.ExportTransactions;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+class ExportTransactionsTest {
+
+    TransactionRepository transactionRepository = Mockito.mock(TransactionRepository.class);
+
+    ExportTransactions exportTransactions;
+
+    @BeforeEach
+    void beforeEach() {
+        this.exportTransactions = new ExportTransactions(transactionRepository);
+    }
+
+    @Test
+    void emptyRepositoryProducesHeaderOnly() {
+        Mockito.when(transactionRepository.search(Mockito.any()))
+                .thenReturn(new PagedResult<>(List.of(), 10000, null));
+
+        String csv = exportTransactions.execute();
+
+        String[] lines = csv.trim().split("\n");
+        Assertions.assertEquals(1, lines.length);
+        Assertions.assertTrue(lines[0].contains("ID"));
+        Assertions.assertTrue(lines[0].contains("Bank"));
+        Assertions.assertTrue(lines[0].contains("Category"));
+    }
+
+    @Test
+    void singleRecordProducesHeaderAndDataLine() {
+        String id = UUID.randomUUID().toString();
+        FinancialRecord record = FinancialRecordTestFactory.createMockFinancialRecord(id);
+        Mockito.when(transactionRepository.search(Mockito.any()))
+                .thenReturn(new PagedResult<>(List.of(record), 10000, null));
+
+        String csv = exportTransactions.execute();
+
+        String[] lines = csv.trim().split("\n");
+        Assertions.assertEquals(2, lines.length);
+        Assertions.assertTrue(lines[1].contains(id));
+        Assertions.assertTrue(lines[1].contains("RANDOM"));
+    }
+
+    @Test
+    void nullFieldsAreWrittenAsEmptyString() {
+        FinancialRecord record = new FinancialRecord(
+                UUID.randomUUID().toString(),
+                "BANK",
+                null,
+                "desc",
+                null,
+                null,
+                "CAT"
+        );
+        Mockito.when(transactionRepository.search(Mockito.any()))
+                .thenReturn(new PagedResult<>(List.of(record), 10000, null));
+
+        String csv = exportTransactions.execute();
+
+        // should not throw; null date/amount/balance become empty strings
+        Assertions.assertNotNull(csv);
+        Assertions.assertTrue(csv.contains("BANK"));
+    }
+
+    @Test
+    void fetchesWithLimitOf10000() {
+        Mockito.when(transactionRepository.search(Mockito.any()))
+                .thenReturn(new PagedResult<>(List.of(), 10000, null));
+
+        exportTransactions.execute();
+
+        ArgumentCaptor<TransactionSearchQuery> captor = ArgumentCaptor.forClass(TransactionSearchQuery.class);
+        Mockito.verify(transactionRepository).search(captor.capture());
+        Assertions.assertEquals(10000, captor.getValue().limit());
+    }
+}

--- a/app/src/test/java/com/moneymind/domain/transactions/GetTransactionTest.java
+++ b/app/src/test/java/com/moneymind/domain/transactions/GetTransactionTest.java
@@ -1,0 +1,53 @@
+package com.moneymind.domain.transactions;
+
+import com.moneymind.FinancialRecordTestFactory;
+import com.moneymind.finance.domain.core.FinancialRecord;
+import com.moneymind.finance.domain.ports.TransactionRepository;
+import com.moneymind.finance.domain.transactions.GetTransaction;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.UUID;
+
+class GetTransactionTest {
+
+    TransactionRepository transactionRepository = Mockito.mock(TransactionRepository.class);
+
+    GetTransaction getTransaction;
+
+    @BeforeEach
+    void beforeEach() {
+        this.getTransaction = new GetTransaction(transactionRepository);
+    }
+
+    @Test
+    void validUuidReturnsRecord() {
+        UUID id = UUID.randomUUID();
+        FinancialRecord expected = FinancialRecordTestFactory.createMockFinancialRecord(id.toString());
+        Mockito.when(transactionRepository.getById(id)).thenReturn(expected);
+
+        FinancialRecord result = getTransaction.execute(id.toString());
+
+        Assertions.assertSame(expected, result);
+    }
+
+    @Test
+    void unknownUuidReturnsNull() {
+        UUID id = UUID.randomUUID();
+        Mockito.when(transactionRepository.getById(id)).thenReturn(null);
+
+        FinancialRecord result = getTransaction.execute(id.toString());
+
+        Assertions.assertNull(result);
+    }
+
+    @Test
+    void malformedUuidReturnsNull() {
+        FinancialRecord result = getTransaction.execute("not-a-uuid");
+
+        Assertions.assertNull(result);
+        Mockito.verify(transactionRepository, Mockito.never()).getById(Mockito.any());
+    }
+}

--- a/app/src/test/java/com/moneymind/domain/transactions/SearchTransactionsTest.java
+++ b/app/src/test/java/com/moneymind/domain/transactions/SearchTransactionsTest.java
@@ -1,0 +1,79 @@
+package com.moneymind.domain.transactions;
+
+import com.moneymind.finance.domain.PagedResult;
+import com.moneymind.finance.domain.core.AggregatedResult;
+import com.moneymind.finance.domain.core.FinancialRecord;
+import com.moneymind.finance.domain.core.SearchResult;
+import com.moneymind.finance.domain.core.TransactionSearchQuery;
+import com.moneymind.finance.domain.ports.TransactionRepository;
+import com.moneymind.finance.domain.transactions.SearchTransactions;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+class SearchTransactionsTest {
+
+    TransactionRepository transactionRepository = Mockito.mock(TransactionRepository.class);
+
+    SearchTransactions searchTransactions;
+
+    @BeforeEach
+    void beforeEach() {
+        this.searchTransactions = new SearchTransactions(transactionRepository);
+    }
+
+    @Test
+    void plainQueryRoutesToRecords() {
+        TransactionSearchQuery query = TransactionSearchQuery.builder().limit(10).build();
+        PagedResult<FinancialRecord> pagedResult = new PagedResult<>(List.of(), 10, null);
+        Mockito.when(transactionRepository.search(query)).thenReturn(pagedResult);
+
+        SearchResult result = searchTransactions.execute(query);
+
+        Assertions.assertInstanceOf(SearchResult.Records.class, result);
+        Assertions.assertSame(pagedResult, ((SearchResult.Records) result).result());
+    }
+
+    @Test
+    void aggregateByPeriodQueryRoutesToAggregated() {
+        TransactionSearchQuery query = TransactionSearchQuery.builder().aggregateByPeriod("MONTH").limit(10).build();
+        PagedResult<AggregatedResult> pagedResult = new PagedResult<>(
+                List.of(new AggregatedResult("2024-01", null, BigDecimal.TEN)), 10, null);
+        Mockito.when(transactionRepository.searchAggregated(query)).thenReturn(pagedResult);
+
+        SearchResult result = searchTransactions.execute(query);
+
+        Assertions.assertInstanceOf(SearchResult.Aggregated.class, result);
+        Assertions.assertSame(pagedResult, ((SearchResult.Aggregated) result).result());
+    }
+
+    @Test
+    void aggregateByColumnQueryRoutesToAggregated() {
+        TransactionSearchQuery query = TransactionSearchQuery.builder().aggregateByColumn("category").limit(10).build();
+        PagedResult<AggregatedResult> pagedResult = new PagedResult<>(
+                List.of(new AggregatedResult(null, "FOOD", BigDecimal.valueOf(50))), 10, null);
+        Mockito.when(transactionRepository.searchAggregated(query)).thenReturn(pagedResult);
+
+        SearchResult result = searchTransactions.execute(query);
+
+        Assertions.assertInstanceOf(SearchResult.Aggregated.class, result);
+    }
+
+    @Test
+    void aggregateByBothPeriodAndColumnRoutesToAggregated() {
+        TransactionSearchQuery query = TransactionSearchQuery.builder()
+                .aggregateByPeriod("YEAR").aggregateByColumn("category").limit(10).build();
+        PagedResult<AggregatedResult> pagedResult = new PagedResult<>(List.of(), 10, null);
+        Mockito.when(transactionRepository.searchAggregated(query)).thenReturn(pagedResult);
+
+        SearchResult result = searchTransactions.execute(query);
+
+        Assertions.assertInstanceOf(SearchResult.Aggregated.class, result);
+        Mockito.verify(transactionRepository).searchAggregated(query);
+        Mockito.verify(transactionRepository, Mockito.never()).search(Mockito.any());
+    }
+}


### PR DESCRIPTION
… (issue 0006)

Tasks completed:
- SearchResult sealed type (Records/Aggregated) added to finance/domain/core/
- SearchTransactions.execute() now owns the aggregate-vs-regular decision; removes executeAggregated()
- ExportTransactions use case extracts CSV logic from the resource into the domain
- GetTransaction.execute() catches IllegalArgumentException for malformed UUIDs, returns null
- TransactionsResource thinned: no isAggregating branch, no CSV logic, pattern-matches on SearchResult
- ExportTransactions wired into DI.java
- SearchResult name added to CONTEXT.md

Files changed:
- domain/core/SearchResult.java (new)
- domain/transactions/SearchTransactions.java
- domain/transactions/ExportTransactions.java (new)
- domain/transactions/GetTransaction.java
- infrastructure/web/http/TransactionsResource.java
- finance/di/DI.java
- test/domain/transactions/SearchTransactionsTest.java (new, 4 tests)
- test/domain/transactions/ExportTransactionsTest.java (new, 4 tests)
- test/domain/transactions/GetTransactionTest.java (new, 3 tests)
- CONTEXT.md

All 52 existing + 11 new tests pass.