### PR TITLE
RALPH: Shrink TransactionClassifier port to one live method (issue 0005)

### DIFF
--- a/app/src/main/java/com/moneymind/finance/di/DI.java
+++ b/app/src/main/java/com/moneymind/finance/di/DI.java
@@ -122,8 +122,7 @@ public class DI {
 
     @ApplicationScoped
     @Produces
-    TransactionClassifier transactionClassifier(final Classifier classifier,
-                                                final TransactionRepository transactionRepository) {
-        return new ClassificationEngine(classifier, transactionRepository);
+    TransactionClassifier transactionClassifier(final Classifier classifier) {
+        return new ClassificationEngine(classifier);
     }
 }

--- a/app/src/main/java/com/moneymind/finance/domain/ports/TransactionClassifier.java
+++ b/app/src/main/java/com/moneymind/finance/domain/ports/TransactionClassifier.java
@@ -5,14 +5,7 @@ import com.moneymind.finance.domain.core.FinancialRecord;
 
 import java.util.List;
 
-/**
- * This eventually can evolve to an automatic system, using ElasticSearch or ML Classification engine
- */
 public interface TransactionClassifier {
-
-    List<FinancialRecord> classify();
-
-    FinancialRecord classify(FinancialRecord financialRecord);
 
     List<ClassifiedFinancialRecord> classify(List<FinancialRecord> financialRecords) throws Exception;
 }

--- a/app/src/main/java/com/moneymind/finance/infrastructure/txClassifier/ClassificationEngine.java
+++ b/app/src/main/java/com/moneymind/finance/infrastructure/txClassifier/ClassificationEngine.java
@@ -3,13 +3,9 @@ package com.moneymind.finance.infrastructure.txClassifier;
 import com.moneymind.classifier.domain.ClassificationResult;
 import com.moneymind.classifier.domain.Transaction;
 import com.moneymind.classifier.ports.Classifier;
-import com.moneymind.finance.domain.PagedResult;
 import com.moneymind.finance.domain.core.ClassifiedFinancialRecord;
 import com.moneymind.finance.domain.core.FinancialRecord;
-import com.moneymind.finance.domain.core.TransactionSearchQuery;
 import com.moneymind.finance.domain.ports.TransactionClassifier;
-import com.moneymind.finance.domain.ports.TransactionRepository;
-import org.jboss.logging.Logger;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -17,46 +13,10 @@ import java.util.List;
 
 public class ClassificationEngine implements TransactionClassifier {
 
-    private final Logger LOG = Logger.getLogger(ClassificationEngine.class);
-
     private final Classifier classifier;
-    private final TransactionRepository transactionRepository;
 
-    public ClassificationEngine(final Classifier classifier,
-                                final TransactionRepository transactionRepository) {
+    public ClassificationEngine(final Classifier classifier) {
         this.classifier = classifier;
-        this.transactionRepository = transactionRepository;
-    }
-
-    @Override
-    public List<FinancialRecord> classify() {
-        TransactionSearchQuery query = TransactionSearchQuery.builder()
-                .limit(80000)
-                .build();
-
-        PagedResult<FinancialRecord> search = transactionRepository.search(query);
-        if (search.list() == null || search.list().isEmpty()) {
-            return List.of();
-        }
-
-        try {
-            List<FinancialRecord> list = search.list()
-                    .stream()
-                    .filter(financialRecord -> financialRecord.getCategory() != null || financialRecord.getCategory().isBlank())
-                    .toList();
-
-            for (FinancialRecord record : list) {
-                classifier.classify(mapToTransaction(record));
-            }
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-        return List.of();
-    }
-
-    @Override
-    public FinancialRecord classify(FinancialRecord financialRecord) {
-        return null;
     }
 
     @Override

--- a/app/src/test/java/com/moneymind/FinancialRecordTestFactory.java
+++ b/app/src/test/java/com/moneymind/FinancialRecordTestFactory.java
@@ -32,5 +32,15 @@ public class FinancialRecordTestFactory {
         );
     }
 
-
+    public static FinancialRecord createUncategorisedRecord() {
+        return new FinancialRecord(
+                UUID.randomUUID().toString(),
+                "RANDOM",
+                OffsetDateTime.now(),
+                "Random text",
+                BigDecimal.valueOf(10.0),
+                BigDecimal.valueOf(10.0),
+                null
+        );
+    }
 }

--- a/app/src/test/java/com/moneymind/domain/txClassifier/ClassificationEngineTest.java
+++ b/app/src/test/java/com/moneymind/domain/txClassifier/ClassificationEngineTest.java
@@ -1,0 +1,89 @@
+package com.moneymind.domain.txClassifier;
+
+import com.moneymind.FinancialRecordTestFactory;
+import com.moneymind.classifier.domain.ClassificationResult;
+import com.moneymind.classifier.domain.Transaction;
+import com.moneymind.classifier.ports.Classifier;
+import com.moneymind.finance.domain.core.ClassifiedFinancialRecord;
+import com.moneymind.finance.domain.core.FinancialRecord;
+import com.moneymind.finance.infrastructure.txClassifier.ClassificationEngine;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ClassificationEngineTest {
+
+    private static final String PREDICTED = "FOOD";
+    private static final double CONFIDENCE = 0.95;
+
+    private Classifier stubClassifier;
+    private ClassificationEngine classificationEngine;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        stubClassifier = new Classifier() {
+            @Override
+            public ClassificationResult classify(Transaction transaction) {
+                return new ClassificationResult(PREDICTED, CONFIDENCE, true);
+            }
+
+            @Override
+            public List<ClassificationResult> classify(List<Transaction> transactions) throws Exception {
+                return transactions.stream()
+                        .map(t -> new ClassificationResult(PREDICTED, CONFIDENCE, true))
+                        .toList();
+            }
+        };
+        classificationEngine = new ClassificationEngine(stubClassifier);
+    }
+
+    @Test
+    void emptyInputYieldsEmptyList() throws Exception {
+        List<ClassifiedFinancialRecord> result = classificationEngine.classify(List.of());
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void nullInputYieldsEmptyList() throws Exception {
+        List<ClassifiedFinancialRecord> result = classificationEngine.classify(null);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void uncategorisedRecordsAreClassified() throws Exception {
+        FinancialRecord uncategorised = FinancialRecordTestFactory.createUncategorisedRecord();
+
+        List<ClassifiedFinancialRecord> result = classificationEngine.classify(List.of(uncategorised));
+
+        assertEquals(1, result.size());
+        ClassifiedFinancialRecord classified = result.get(0);
+        assertEquals(PREDICTED, classified.category());
+        assertEquals(new BigDecimal(CONFIDENCE), classified.classificationConfidence());
+        assertEquals(uncategorised, classified.record());
+    }
+
+    @Test
+    void alreadyCategorisedRecordsAreFilteredOut() throws Exception {
+        FinancialRecord categorised = FinancialRecordTestFactory.createMockFinancialRecord();
+        // createMockFinancialRecord sets category to "RANDOM CAT" — already categorised
+
+        List<ClassifiedFinancialRecord> result = classificationEngine.classify(List.of(categorised));
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void mixedListOnlyClassifiesUncategorised() throws Exception {
+        FinancialRecord categorised = FinancialRecordTestFactory.createMockFinancialRecord();
+        FinancialRecord uncategorised = FinancialRecordTestFactory.createUncategorisedRecord();
+
+        List<ClassifiedFinancialRecord> result = classificationEngine.classify(List.of(categorised, uncategorised));
+
+        assertEquals(1, result.size());
+        assertEquals(uncategorised, result.get(0).record());
+    }
+}


### PR DESCRIPTION
Removed classify() and classify(FinancialRecord) from the port and their dead implementations from ClassificationEngine. ClassificationEngine no longer depends on TransactionRepository. DI.java updated accordingly.

Unit test ClassificationEngineTest covers:
- Empty/null input → empty list
- Uncategorised records → ClassifiedFinancialRecord with predicted category + confidence
- Already-categorised records → filtered out, absent from result
- Mixed list → only uncategorised are classified

All 46 tests pass (5 new + 41 existing).