### PR TITLE
RALPH: Rules-first hybrid classifier + confidence gating + GuestImpor…

### DIFF
--- a/app/src/main/java/com/moneymind/finance/domain/guest/GuestImport.java
+++ b/app/src/main/java/com/moneymind/finance/domain/guest/GuestImport.java
@@ -132,14 +132,16 @@ public class GuestImport {
     }
 
     private Map<String, Resolved> resolveCategoryTypes() {
-        final Map<String, Resolved> bySubcategory = new LinkedHashMap<>();
+        final Map<String, Resolved> byName = new LinkedHashMap<>();
         // null userId → system/global categories (not user-scoped)
         for (Category category : categoryRepository.findCategories(null)) {
+            // Parent category entry so classifier outputs like "INCOME" or "HOUSING" resolve correctly
+            byName.put(category.name(), new Resolved(category.name(), category.type()));
             for (Category sub : category.subcategories()) {
-                bySubcategory.put(sub.name(), new Resolved(category.name(), sub.type()));
+                byName.put(sub.name(), new Resolved(category.name(), sub.type()));
             }
         }
-        return bySubcategory;
+        return byName;
     }
 
     private static String period(final ClassifiedFinancialRecord record) {

--- a/app/src/test/java/com/moneymind/domain/guest/GuestImportTest.java
+++ b/app/src/test/java/com/moneymind/domain/guest/GuestImportTest.java
@@ -128,6 +128,48 @@ class GuestImportTest {
     }
 
     @Test
+    void unrecognisedCreditClassifiedAsIncomeDoesNotCorruptExpenseTotal() throws Exception {
+        // If an unrecognised credit (e.g. tax refund) lands in MISCELLANEOUS (EXPENSE type),
+        // SummaryEngine negates it → negative expense total and negative shares.
+        // The classifier must route credits to an INCOME-type category instead.
+        FinancialRecord refund = record("2026-05-10", "REEMBOLSO IRS 2024", new BigDecimal("320.00"));
+        FinancialRecord rent   = record("2026-05-02", "Renda",              new BigDecimal("-750.00"));
+
+        givenDetectedBank("CGD", refund, rent);
+        givenClassifications(
+                classified("INCOME", refund),   // credit classified as INCOME (correct)
+                classified("RENT",   rent));     // debit classified as RENT (correct)
+
+        MonthlyReview may = guestImport.execute(csv()).months().get(0);
+
+        assertTrue(may.income().compareTo(BigDecimal.ZERO) > 0, "income must be positive");
+        assertTrue(may.expense().compareTo(BigDecimal.ZERO) > 0, "expense must be positive");
+        may.categories().forEach(c ->
+                assertTrue(c.share() >= 0, "share must be non-negative for " + c.name()));
+    }
+
+    @Test
+    void parentCategoryNameResolvesCorrectly() throws Exception {
+        // Classifier outputs parent category names ("INCOME", "HOUSING") — from ClassificationRules —
+        // rather than subcategory names ("SALARY", "RENT"). The lookup must handle both.
+        FinancialRecord salary = record("2026-05-31", "VENCIMENTO MAIO", new BigDecimal("2600.00"));
+        FinancialRecord rent   = record("2026-05-02", "RENDA APARTAMENTO", new BigDecimal("-900.00"));
+
+        givenDetectedBank("CGD", salary, rent);
+        givenClassifications(classified("INCOME", salary), classified("HOUSING", rent));
+
+        MonthlyReview may = guestImport.execute(csv()).months().get(0);
+
+        assertAmount("2600.00", may.income());
+        assertAmount("900.00",  may.expense());
+        assertAmount("1700.00", may.savings());
+        assertTrue(may.categories().stream().anyMatch(c -> c.name().equals("HOUSING")),
+                "HOUSING expense category must appear in the breakdown");
+        assertTrue(may.categories().stream().noneMatch(c -> c.name().equals("INCOME")),
+                "INCOME category must be excluded from the expense breakdown");
+    }
+
+    @Test
     void throwsWhenNoRegisteredParserCanReadTheFile() throws Exception {
         Mockito.when(bankRegistry.listAvailable()).thenReturn(java.util.Set.of("CGD"));
         Mockito.when(bankRegistry.getParser("CGD")).thenReturn(parser);

--- a/classifier/src/main/java/com/moneymind/classifier/HybridClassifier.java
+++ b/classifier/src/main/java/com/moneymind/classifier/HybridClassifier.java
@@ -1,0 +1,77 @@
+package com.moneymind.classifier;
+
+import com.moneymind.classifier.domain.ClassificationResult;
+import com.moneymind.classifier.domain.ClassificationRules;
+import com.moneymind.classifier.domain.Transaction;
+import com.moneymind.classifier.ports.Classifier;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Rules-first hybrid classifier: applies deterministic keyword rules before falling back to the
+ * Weka ML model. When ML confidence is below the threshold (or the model is unavailable), the
+ * fallback uses the transaction's amount sign to pick a safe category:
+ * <ul>
+ *   <li>Credit (positive amount) → INCOME — keeps credits in an INCOME-type category so they
+ *       never inflate the expense total with a negative contribution.
+ *   <li>Debit (negative/zero amount) → MISCELLANEOUS — standard expense catch-all.
+ * </ul>
+ *
+ * <p>Confidence threshold matches WekaRandomForestClassifier.MIN_CONFIDENCE_THRESHOLD (0.6).
+ */
+public class HybridClassifier implements Classifier {
+
+    static final String MISCELLANEOUS = "MISCELLANEOUS";
+    static final double MIN_CONFIDENCE = 0.6;
+
+    private final ClassificationRules rules;
+    private final Classifier mlClassifier;
+
+    public HybridClassifier(ClassificationRules rules, Classifier mlClassifier) {
+        this.rules = rules;
+        this.mlClassifier = mlClassifier;
+    }
+
+    @Override
+    public ClassificationResult classify(Transaction transaction) throws Exception {
+        Optional<String> ruleMatch = rules.match(transaction.description());
+        if (ruleMatch.isPresent()) {
+            return new ClassificationResult(ruleMatch.get(), 1.0, true);
+        }
+
+        try {
+            ClassificationResult mlResult = mlClassifier.classify(transaction);
+            if (mlResult.confidence() >= MIN_CONFIDENCE) {
+                return mlResult;
+            }
+            return amountSignFallback(transaction, mlResult.confidence());
+        } catch (Exception e) {
+            // ML unavailable (e.g. insufficient training data): fall back on amount sign
+            return amountSignFallback(transaction, 0.0);
+        }
+    }
+
+    /**
+     * Uses the transaction amount sign as a tie-breaker when ML is low-confidence or unavailable.
+     * Credits (positive) belong in INCOME; debits (negative/zero/null) belong in MISCELLANEOUS.
+     */
+    private static ClassificationResult amountSignFallback(Transaction transaction, double confidence) {
+        boolean isCredit = transaction.amount() != null && transaction.amount().signum() > 0;
+        String category = isCredit ? ClassificationRules.CAT_INCOME : MISCELLANEOUS;
+        return new ClassificationResult(category, confidence, false);
+    }
+
+    @Override
+    public List<ClassificationResult> classify(List<Transaction> transactions) throws Exception {
+        return transactions.stream()
+                .map(t -> {
+                    try {
+                        return classify(t);
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                })
+                .toList();
+    }
+}

--- a/classifier/src/main/java/com/moneymind/classifier/WekaRandomForestClassifier.java
+++ b/classifier/src/main/java/com/moneymind/classifier/WekaRandomForestClassifier.java
@@ -87,10 +87,11 @@ public class WekaRandomForestClassifier implements Classifier {
             }
         }
 
-        // Calculate TF-IDF weights for top words, preserving insertion order for stable indexing
+        // Calculate TF-IDF weights for top words, preserving insertion order for stable indexing.
+        // Single-occurrence words are retained: in Portuguese banking data most merchants appear
+        // once or twice per statement, so they are exactly the discriminative signal we need.
         Map<String, Double> vocabulary = new LinkedHashMap<>();
         wordCount.entrySet().stream()
-                .filter(entry -> entry.getValue() > 1) // Filter rare words
                 .sorted(Map.Entry.<String, Integer>comparingByValue().reversed())
                 .limit(200) // Top 200 words
                 .forEach(entry -> {

--- a/classifier/src/main/java/com/moneymind/classifier/di/DI.java
+++ b/classifier/src/main/java/com/moneymind/classifier/di/DI.java
@@ -1,6 +1,8 @@
 package com.moneymind.classifier.di;
 
+import com.moneymind.classifier.HybridClassifier;
 import com.moneymind.classifier.WekaRandomForestClassifier;
+import com.moneymind.classifier.domain.ClassificationRules;
 import com.moneymind.classifier.infrastructure.postgres.TransactionRepository;
 import com.moneymind.classifier.ports.Classifier;
 import com.moneymind.classifier.ports.TrainingDataService;
@@ -25,6 +27,7 @@ public class DI {
     @ApplicationScoped
     @Produces
     Classifier produceClassifier(final TrainingDataService trainingDataService) throws Exception {
-        return new WekaRandomForestClassifier(trainingDataService);
+        WekaRandomForestClassifier weka = new WekaRandomForestClassifier(trainingDataService);
+        return new HybridClassifier(new ClassificationRules(), weka);
     }
 }

--- a/classifier/src/main/java/com/moneymind/classifier/domain/ClassificationRules.java
+++ b/classifier/src/main/java/com/moneymind/classifier/domain/ClassificationRules.java
@@ -1,0 +1,184 @@
+package com.moneymind.classifier.domain;
+
+import java.text.Normalizer;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Data-driven keyword to category map applied before the ML model. Rules are checked in order;
+ * first match wins. Descriptions are normalised to uppercase ASCII before matching so accented
+ * variants ("FARMACIA" == "FARMACIA") are treated identically.
+ *
+ * EXCLUDED-type outcomes (TRANSFERS) must only arrive here via an explicit rule, never from a
+ * low-confidence ML prediction. Self-transfer and savings rules are listed first so they take
+ * precedence over any overlapping expense keywords.
+ */
+public final class ClassificationRules {
+
+    public record Rule(String keyword, String category) {}
+
+    public static final String CAT_TRANSFERS     = "TRANSFERS";
+    public static final String CAT_SAVINGS       = "SAVINGS & INVESTMENTS";
+    public static final String CAT_INCOME        = "INCOME";
+    public static final String CAT_HOUSING       = "HOUSING";
+    public static final String CAT_FOOD          = "FOOD & DINING";
+    public static final String CAT_TRANSPORT     = "TRANSPORT";
+    public static final String CAT_HEALTH        = "HEALTH";
+    public static final String CAT_SUBSCRIPTIONS = "SUBSCRIPTIONS";
+    public static final String CAT_TRAVEL        = "TRAVEL";
+    public static final String CAT_ENTERTAINMENT = "ENTERTAINMENT";
+    public static final String CAT_MISCELLANEOUS = "MISCELLANEOUS";
+
+    /**
+     * Default Portuguese-merchant rule set. EXCLUDED-producing rules (TRANSFERS) are listed first
+     * so a description matching both a self-transfer keyword and an expense keyword resolves to
+     * TRANSFERS.
+     */
+    static final List<Rule> DEFAULT_RULES = List.of(
+        // EXCLUDED — explicit self-transfer patterns only
+        new Rule("TRANSFERENCIA ENTRE CONTAS",     CAT_TRANSFERS),
+        new Rule("TRANSF ENTRE CONTAS",            CAT_TRANSFERS),
+        new Rule("MB WAY SAIDA",                   CAT_TRANSFERS),
+
+        // SAVINGS & INVESTMENTS
+        new Rule("POUPANCA",                       CAT_SAVINGS),
+        new Rule("DEPOSITO A PRAZO",               CAT_SAVINGS),
+        new Rule("DEPOSITO PRAZO",                 CAT_SAVINGS),
+        new Rule("PPR ",                           CAT_SAVINGS),
+
+        // INCOME
+        new Rule("ORDENADO",                       CAT_INCOME),
+        new Rule("VENCIMENTO",                     CAT_INCOME),
+        new Rule("SALARIO",                        CAT_INCOME),
+        new Rule("REMUNERACAO",                    CAT_INCOME),
+        new Rule("SUBSIDIO FERIAS",                CAT_INCOME),
+        new Rule("SUBSIDIO NATAL",                 CAT_INCOME),
+
+        // HOUSING
+        new Rule("RENDA ",                         CAT_HOUSING),
+        new Rule("CONDOMINIO",                     CAT_HOUSING),
+        new Rule("EDP ",                           CAT_HOUSING),
+        new Rule("ENDESA",                         CAT_HOUSING),
+        new Rule("ENEL ",                          CAT_HOUSING),
+        new Rule("GALP GAS",                       CAT_HOUSING),
+        new Rule("AGUAS DE ",                      CAT_HOUSING),
+        new Rule("AGUAS DO ",                      CAT_HOUSING),
+
+        // FOOD & DINING
+        new Rule("CONTINENTE",                     CAT_FOOD),
+        new Rule("PINGO DOCE",                     CAT_FOOD),
+        new Rule("AUCHAN",                         CAT_FOOD),
+        new Rule("LIDL",                           CAT_FOOD),
+        new Rule("MINIPRECO",                      CAT_FOOD),
+        new Rule("INTERMARCHE",                    CAT_FOOD),
+        new Rule("MERCADONA",                      CAT_FOOD),
+        new Rule("TELEPIZZA",                      CAT_FOOD),
+        new Rule("DOMINOS",                        CAT_FOOD),
+        new Rule("MCDONALD",                       CAT_FOOD),
+        new Rule("KFC",                            CAT_FOOD),
+        new Rule("NANDOS",                         CAT_FOOD),
+        new Rule("PIZZA HUT",                      CAT_FOOD),
+        new Rule("UBER EATS",                      CAT_FOOD),
+        new Rule("GLOVO",                          CAT_FOOD),
+        new Rule("ZOMATO",                         CAT_FOOD),
+
+        // TRANSPORT
+        new Rule("VIA VERDE",                      CAT_TRANSPORT),
+        new Rule("VIA-VERDE",                      CAT_TRANSPORT),
+        new Rule("CP COMBOIOS",                    CAT_TRANSPORT),
+        new Rule("COMBOIOS DE PORTUGAL",           CAT_TRANSPORT),
+        new Rule("METRO DE LISBOA",                CAT_TRANSPORT),
+        new Rule("METRO DO PORTO",                 CAT_TRANSPORT),
+        new Rule("REPSOL",                         CAT_TRANSPORT),
+        new Rule("CEPSA",                          CAT_TRANSPORT),
+        new Rule("GALP",                           CAT_TRANSPORT),
+        new Rule("GIRA ",                          CAT_TRANSPORT),
+        new Rule("BOLT ",                          CAT_TRANSPORT),
+        new Rule("UBER ",                          CAT_TRANSPORT),
+        new Rule("CABIFY",                         CAT_TRANSPORT),
+        new Rule("ESSO ",                          CAT_TRANSPORT),
+        new Rule("BP ",                            CAT_TRANSPORT),
+
+        // HEALTH
+        new Rule("FARMACIA",                       CAT_HEALTH),
+        new Rule("CLINICA",                        CAT_HEALTH),
+        new Rule("DENTISTA",                       CAT_HEALTH),
+        new Rule("DENTAL",                         CAT_HEALTH),
+        new Rule("HOSPITAL",                       CAT_HEALTH),
+        new Rule("LABORATORIO",                    CAT_HEALTH),
+        new Rule("OPTICA",                         CAT_HEALTH),
+        new Rule("HOLMES PLACE",                   CAT_HEALTH),
+        new Rule("GINASIO",                        CAT_HEALTH),
+
+        // SUBSCRIPTIONS
+        new Rule("NETFLIX",                        CAT_SUBSCRIPTIONS),
+        new Rule("SPOTIFY",                        CAT_SUBSCRIPTIONS),
+        new Rule("HBO MAX",                        CAT_SUBSCRIPTIONS),
+        new Rule("PRIME VIDEO",                    CAT_SUBSCRIPTIONS),
+        new Rule("APPLE.COM",                      CAT_SUBSCRIPTIONS),
+        new Rule("APPLE SUBSCRIPTIONS",            CAT_SUBSCRIPTIONS),
+        new Rule("GOOGLE ONE",                     CAT_SUBSCRIPTIONS),
+        new Rule("YOUTUBE PREMIUM",                CAT_SUBSCRIPTIONS),
+        new Rule("NOS ",                           CAT_SUBSCRIPTIONS),
+        new Rule("MEO ",                           CAT_SUBSCRIPTIONS),
+        new Rule("VODAFONE",                       CAT_SUBSCRIPTIONS),
+        new Rule("NESPRESSO",                      CAT_SUBSCRIPTIONS),
+
+        // TRAVEL
+        new Rule("RYANAIR",                        CAT_TRAVEL),
+        new Rule("TAP AIR",                        CAT_TRAVEL),
+        new Rule("EASYJET",                        CAT_TRAVEL),
+        new Rule("TRANSAVIA",                      CAT_TRAVEL),
+        new Rule("VUELING",                        CAT_TRAVEL),
+        new Rule("BOOKING.COM",                    CAT_TRAVEL),
+        new Rule("AIRBNB",                         CAT_TRAVEL),
+        new Rule("RENTALCARS",                     CAT_TRAVEL),
+        new Rule("HERTZ",                          CAT_TRAVEL),
+        new Rule("EUROPCAR",                       CAT_TRAVEL),
+
+        // ENTERTAINMENT
+        new Rule("NOS CINEMAS",                    CAT_ENTERTAINMENT),
+        new Rule("CINEMA",                         CAT_ENTERTAINMENT),
+        new Rule("STEAM",                          CAT_ENTERTAINMENT),
+        new Rule("PLAYSTATION",                    CAT_ENTERTAINMENT),
+        new Rule("XBOX",                           CAT_ENTERTAINMENT),
+        new Rule("NINTENDO",                       CAT_ENTERTAINMENT)
+    );
+
+    private final List<Rule> rules;
+
+    public ClassificationRules() {
+        this(DEFAULT_RULES);
+    }
+
+    public ClassificationRules(List<Rule> rules) {
+        this.rules = rules;
+    }
+
+    /**
+     * Returns the first category whose keyword is found as a substring in the normalised
+     * description, or empty when no rule matches.
+     */
+    public Optional<String> match(String description) {
+        if (description == null || description.isBlank()) {
+            return Optional.empty();
+        }
+        String normalised = normalise(description);
+        for (Rule rule : rules) {
+            if (normalised.contains(normalise(rule.keyword()))) {
+                return Optional.of(rule.category());
+            }
+        }
+        return Optional.empty();
+    }
+
+    /** Uppercases, strips combining diacritical marks, collapses punctuation and multiple spaces. */
+    static String normalise(String text) {
+        String decomposed = Normalizer.normalize(text.toUpperCase(), Normalizer.Form.NFD);
+        return decomposed
+                .replaceAll("[\\u0300-\\u036f]", "")
+                .replaceAll("[^A-Z0-9\\s]", " ")
+                .replaceAll("\\s+", " ")
+                .trim();
+    }
+}

--- a/classifier/src/main/java/com/moneymind/classifier/domain/FeatureExtractor.java
+++ b/classifier/src/main/java/com/moneymind/classifier/domain/FeatureExtractor.java
@@ -1,6 +1,7 @@
 package com.moneymind.classifier.domain;
 
 import java.math.BigDecimal;
+import java.text.Normalizer;
 import java.time.LocalDate;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -58,15 +59,19 @@ public final class FeatureExtractor {
     }
 
     /**
-     * Lowercase, strip non-alphanumerics, keep tokens longer than two characters. Null/empty/fully
-     * masked descriptions yield an empty set (the amount + period features still carry signal).
+     * Strip accents, lowercase, drop non-alphanumerics, keep tokens longer than two characters.
+     * Accent stripping means "FARMACIA" and "FARMACIA" (accented) share the same token, improving
+     * ML signal for Portuguese merchants. Null/empty/fully masked descriptions yield an empty set
+     * (the amount + period features still carry signal).
      */
     public Set<String> tokens(String description) {
         Set<String> tokens = new LinkedHashSet<>();
         if (description == null || description.isBlank()) {
             return tokens;
         }
-        String[] candidates = description.toLowerCase()
+        String stripped = Normalizer.normalize(description, Normalizer.Form.NFD)
+                .replaceAll("[\\u0300-\\u036f]", "");
+        String[] candidates = stripped.toLowerCase()
                 .replaceAll("[^a-z0-9\\s]", " ")
                 .split("\\s+");
         for (String candidate : candidates) {

--- a/classifier/src/test/java/com/moneymind/classifier/HybridClassifierTest.java
+++ b/classifier/src/test/java/com/moneymind/classifier/HybridClassifierTest.java
@@ -1,0 +1,208 @@
+package com.moneymind.classifier;
+
+import com.moneymind.classifier.domain.ClassificationResult;
+import com.moneymind.classifier.domain.ClassificationRules;
+import com.moneymind.classifier.domain.Transaction;
+import com.moneymind.classifier.ports.Classifier;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Pure unit tests (no mocks, no DB) for {@link HybridClassifier}, covering:
+ * - rule match wins regardless of ML result
+ * - high-confidence ML result is forwarded
+ * - low-confidence ML falls back based on amount sign (credit→INCOME, debit→MISCELLANEOUS)
+ * - ML exception falls back based on amount sign
+ * - low-confidence ML never returns an EXCLUDED-type category (TRANSFERS)
+ */
+class HybridClassifierTest {
+
+    private Classifier stubMl(ClassificationResult result) {
+        return new Classifier() {
+            @Override
+            public ClassificationResult classify(Transaction t) {
+                return result;
+            }
+
+            @Override
+            public List<ClassificationResult> classify(List<Transaction> ts) {
+                return ts.stream().map(t -> result).toList();
+            }
+        };
+    }
+
+    private Classifier failingMl() {
+        return new Classifier() {
+            @Override
+            public ClassificationResult classify(Transaction t) throws Exception {
+                throw new IllegalStateException("Insufficient training data");
+            }
+
+            @Override
+            public List<ClassificationResult> classify(List<Transaction> ts) throws Exception {
+                throw new IllegalStateException("Insufficient training data");
+            }
+        };
+    }
+
+    private Transaction debit(String description, String amount) {
+        return new Transaction(description, null, new BigDecimal("-" + amount), LocalDate.now());
+    }
+
+    private Transaction credit(String description, String amount) {
+        return new Transaction(description, null, new BigDecimal(amount), LocalDate.now());
+    }
+
+    private Transaction noAmount(String description) {
+        return new Transaction(description, null, null, null);
+    }
+
+    // --- rule wins ---
+
+    @Test
+    void ruleMatch_returnsRuleCategory_ignoringML() throws Exception {
+        HybridClassifier hybrid = new HybridClassifier(
+                new ClassificationRules(List.of(new ClassificationRules.Rule("CONTINENTE", "FOOD & DINING"))),
+                stubMl(new ClassificationResult("TRANSFERS", 0.99, true))
+        );
+
+        ClassificationResult result = hybrid.classify(credit("CONTINENTE BELEM LISBOA", "63.15"));
+
+        assertEquals("FOOD & DINING", result.predictedCategory());
+        assertEquals(1.0, result.confidence());
+        assertTrue(result.highConfidence());
+    }
+
+    // --- high-confidence ML ---
+
+    @Test
+    void highConfidenceML_isForwarded_whenNoRuleMatches() throws Exception {
+        ClassificationResult mlResult = new ClassificationResult("HOUSING", 0.85, true);
+        HybridClassifier hybrid = new HybridClassifier(
+                new ClassificationRules(List.of()),
+                stubMl(mlResult)
+        );
+
+        ClassificationResult result = hybrid.classify(debit("SOME LANDLORD PAYMENT", "900.00"));
+
+        assertEquals("HOUSING", result.predictedCategory());
+        assertEquals(0.85, result.confidence(), 1e-9);
+        assertTrue(result.highConfidence());
+    }
+
+    @Test
+    void confidenceBoundary_exactThreshold_isForwarded() throws Exception {
+        ClassificationResult atThreshold = new ClassificationResult("TRANSPORT", HybridClassifier.MIN_CONFIDENCE, true);
+        HybridClassifier hybrid = new HybridClassifier(
+                new ClassificationRules(List.of()),
+                stubMl(atThreshold)
+        );
+
+        ClassificationResult result = hybrid.classify(debit("SOME TRANSPORT MERCHANT", "50.00"));
+
+        assertEquals("TRANSPORT", result.predictedCategory());
+    }
+
+    // --- low-confidence fallback: amount-sign aware ---
+
+    @Test
+    void lowConfidenceML_debitFallsBackToMiscellaneous() throws Exception {
+        HybridClassifier hybrid = new HybridClassifier(
+                new ClassificationRules(List.of()),
+                stubMl(new ClassificationResult("HEALTH", 0.35, false))
+        );
+
+        ClassificationResult result = hybrid.classify(debit("UNKNOWN MERCHANT", "60.00"));
+
+        assertEquals(HybridClassifier.MISCELLANEOUS, result.predictedCategory());
+        assertFalse(result.highConfidence());
+    }
+
+    @Test
+    void lowConfidenceML_creditFallsBackToIncome() throws Exception {
+        // An unrecognised credit (positive amount, e.g. salary not matched by rules) must NOT
+        // end up in MISCELLANEOUS (EXPENSE type) — that would make the expense total negative.
+        HybridClassifier hybrid = new HybridClassifier(
+                new ClassificationRules(List.of()),
+                stubMl(new ClassificationResult("MISCELLANEOUS", 0.2, false))
+        );
+
+        ClassificationResult result = hybrid.classify(credit("UNKNOWN CREDIT ENTRY", "2600.00"));
+
+        assertEquals(ClassificationRules.CAT_INCOME, result.predictedCategory());
+        assertFalse(result.highConfidence());
+    }
+
+    @Test
+    void lowConfidenceML_nullAmountFallsBackToMiscellaneous() throws Exception {
+        HybridClassifier hybrid = new HybridClassifier(
+                new ClassificationRules(List.of()),
+                stubMl(new ClassificationResult("HOUSING", 0.1, false))
+        );
+
+        ClassificationResult result = hybrid.classify(noAmount("UNKNOWN TRANSACTION"));
+
+        assertEquals(HybridClassifier.MISCELLANEOUS, result.predictedCategory());
+    }
+
+    @Test
+    void lowConfidenceML_neverReturnsExcludedCategory() throws Exception {
+        // ML predicts TRANSFERS (EXCLUDED type) with low confidence — must be overridden
+        HybridClassifier hybrid = new HybridClassifier(
+                new ClassificationRules(List.of()),
+                stubMl(new ClassificationResult("TRANSFERS", 0.45, false))
+        );
+
+        ClassificationResult result = hybrid.classify(debit("AMBIGUOUS TRANSACTION", "100.00"));
+
+        assertEquals(HybridClassifier.MISCELLANEOUS, result.predictedCategory());
+        assertFalse(result.highConfidence());
+    }
+
+    // --- ML exception fallback ---
+
+    @Test
+    void mlException_creditFallsBackToIncome() throws Exception {
+        HybridClassifier hybrid = new HybridClassifier(new ClassificationRules(List.of()), failingMl());
+
+        ClassificationResult result = hybrid.classify(credit("SALARY DEPOSIT", "3000.00"));
+
+        assertEquals(ClassificationRules.CAT_INCOME, result.predictedCategory());
+        assertEquals(0.0, result.confidence(), 1e-9);
+    }
+
+    @Test
+    void mlException_debitFallsBackToMiscellaneous() throws Exception {
+        HybridClassifier hybrid = new HybridClassifier(new ClassificationRules(List.of()), failingMl());
+
+        ClassificationResult result = hybrid.classify(debit("UNKNOWN EXPENSE", "150.00"));
+
+        assertEquals(HybridClassifier.MISCELLANEOUS, result.predictedCategory());
+    }
+
+    // --- batch classify ---
+
+    @Test
+    void batchClassify_appliesHybridLogicToAll() throws Exception {
+        HybridClassifier hybrid = new HybridClassifier(
+                new ClassificationRules(List.of(new ClassificationRules.Rule("CONTINENTE", "FOOD & DINING"))),
+                stubMl(new ClassificationResult("TRANSFERS", 0.2, false))
+        );
+
+        List<ClassificationResult> results = hybrid.classify(List.of(
+                credit("CONTINENTE BELEM", "63.15"),  // rule match
+                debit("RANDOM MERCHANT", "50.00"),    // low confidence debit → MISCELLANEOUS
+                credit("UNKNOWN CREDIT", "500.00")    // low confidence credit → INCOME
+        ));
+
+        assertEquals(3, results.size());
+        assertEquals("FOOD & DINING", results.get(0).predictedCategory());
+        assertEquals(HybridClassifier.MISCELLANEOUS, results.get(1).predictedCategory());
+        assertEquals(ClassificationRules.CAT_INCOME, results.get(2).predictedCategory());
+    }
+}

--- a/classifier/src/test/java/com/moneymind/classifier/domain/ClassificationRulesTest.java
+++ b/classifier/src/test/java/com/moneymind/classifier/domain/ClassificationRulesTest.java
@@ -1,0 +1,136 @@
+package com.moneymind.classifier.domain;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Pure unit tests (no mocks) for {@link ClassificationRules}.
+ */
+class ClassificationRulesTest {
+
+    private final ClassificationRules rules = new ClassificationRules();
+
+    // --- normalise ---
+
+    @Test
+    void normalise_uppercasesAndStripsPunctuation() {
+        assertEquals("PINGO DOCE LISBOA", ClassificationRules.normalise("pingo.doce lisboa"));
+    }
+
+    @Test
+    void normalise_stripsCombiningAccents() {
+        // U+00C1 LATIN CAPITAL LETTER A WITH ACUTE
+        String farmacia = "FARMÁCIA";
+        assertEquals("FARMACIA", ClassificationRules.normalise(farmacia));
+    }
+
+    @Test
+    void normalise_stripsLowercaseAccents() {
+        // U+00E1 LATIN SMALL LETTER A WITH ACUTE
+        String farmacia = "farmácia";
+        assertEquals("FARMACIA", ClassificationRules.normalise(farmacia));
+    }
+
+    @Test
+    void normalise_collapsesMultipleSpaces() {
+        assertEquals("A B C", ClassificationRules.normalise("a  b   c"));
+    }
+
+    // --- match: known merchants ---
+
+    @Test
+    void knownMerchant_continente_matchesFood() {
+        assertEquals(Optional.of(ClassificationRules.CAT_FOOD), rules.match("CONTINENTE HIPERMERCADOS LISBOA"));
+    }
+
+    @Test
+    void knownMerchant_ryanair_matchesTravel() {
+        assertEquals(Optional.of(ClassificationRules.CAT_TRAVEL), rules.match("RYANAIR LTD DUBLIN"));
+    }
+
+    @Test
+    void knownMerchant_bookingCom_matchesTravel() {
+        // description has a space where the dot was; keyword must be normalised too
+        assertEquals(Optional.of(ClassificationRules.CAT_TRAVEL), rules.match("BOOKING COM HOTEL MADRID"));
+    }
+
+    @Test
+    void knownMerchant_ordenado_matchesIncome() {
+        assertEquals(Optional.of(ClassificationRules.CAT_INCOME), rules.match("ORDENADO TECHCORP LDA"));
+    }
+
+    @Test
+    void knownMerchant_netflix_matchesSubscriptions() {
+        assertEquals(Optional.of(ClassificationRules.CAT_SUBSCRIPTIONS), rules.match("NETFLIX.COM"));
+    }
+
+    @Test
+    void accentedDescription_farmacia_matchesHealth() {
+        // U+00C1 = A-acute: "FARMÁCIA SANTA ANA" normalises to "FARMACIA SANTA ANA"
+        assertEquals(Optional.of(ClassificationRules.CAT_HEALTH),
+                rules.match("FARMÁCIA SANTA ANA LISBOA"));
+    }
+
+    @Test
+    void accentedDescription_poupanca_matchesSavings() {
+        // U+00E7 = c-cedilla, U+00E3 = a-tilde: "poupança" -> "POUPANCA"
+        assertEquals(Optional.of(ClassificationRules.CAT_SAVINGS),
+                rules.match("poupança automática maio"));
+    }
+
+    // --- match: EXCLUDED only via explicit rule ---
+
+    @Test
+    void selfTransferKeyword_mapsToTransfers() {
+        assertEquals(Optional.of(ClassificationRules.CAT_TRANSFERS),
+                rules.match("TRANSFERENCIA ENTRE CONTAS PROPRIAS"));
+    }
+
+    @Test
+    void transferRuleTakesPrecedenceOverExpenseKeyword() {
+        ClassificationRules withTransferFirst = new ClassificationRules(List.of(
+                new ClassificationRules.Rule("TRANSFERENCIA ENTRE CONTAS", ClassificationRules.CAT_TRANSFERS),
+                new ClassificationRules.Rule("GALP", ClassificationRules.CAT_TRANSPORT)
+        ));
+        assertEquals(Optional.of(ClassificationRules.CAT_TRANSFERS),
+                withTransferFirst.match("TRANSFERENCIA ENTRE CONTAS GALP REFERENCIA"));
+    }
+
+    // --- match: unknown merchant ---
+
+    @Test
+    void unknownMerchant_returnsEmpty() {
+        assertTrue(rules.match("RANDOM UNKNOWN MERCHANT XYZ 1234").isEmpty());
+    }
+
+    @Test
+    void nullDescription_returnsEmpty() {
+        assertTrue(rules.match(null).isEmpty());
+    }
+
+    @Test
+    void blankDescription_returnsEmpty() {
+        assertTrue(rules.match("   ").isEmpty());
+    }
+
+    // --- custom rules ---
+
+    @Test
+    void customRules_firstMatchWins() {
+        ClassificationRules custom = new ClassificationRules(List.of(
+                new ClassificationRules.Rule("ALPHA", "CAT_A"),
+                new ClassificationRules.Rule("ALPHA", "CAT_B")
+        ));
+        assertEquals(Optional.of("CAT_A"), custom.match("ALPHA BETA"));
+    }
+
+    @Test
+    void emptyRuleList_alwaysReturnsEmpty() {
+        ClassificationRules empty = new ClassificationRules(List.of());
+        assertTrue(empty.match("NETFLIX CONTINENTE RYANAIR").isEmpty());
+    }
+}

--- a/classifier/src/test/java/com/moneymind/classifier/domain/FeatureExtractorTest.java
+++ b/classifier/src/test/java/com/moneymind/classifier/domain/FeatureExtractorTest.java
@@ -91,6 +91,15 @@ class FeatureExtractorTest {
     }
 
     @Test
+    void tokens_stripsAccentsSoAccentedAndUnaccentedShareToken() {
+        // "FARMÁCIA" (U+00C1 = A-acute) should produce token "farmacia", same as plain "FARMACIA"
+        var withAccent = extractor.tokens("FARMÁCIA SANTA ANA");
+        var withoutAccent = extractor.tokens("FARMACIA SANTA ANA");
+        assertEquals(withoutAccent, withAccent);
+        assertTrue(withAccent.contains("farmacia"));
+    }
+
+    @Test
     void extract_maskedDescriptionStillYieldsUsableAmountAndPeriodFeatures() {
         Transaction masked = new Transaction(
                 "351 9******* transfer", "INCOME", new BigDecimal("1200.00"), LocalDate.of(2026, 1, 2));


### PR DESCRIPTION
…t sign fix (issue 0016)

## What
- NEW ClassificationRules: data-driven keyword→category map (60+ Portuguese merchant rules). EXCLUDED-producing rules (TRANSFERS) listed first. NFD accent normalisation so FARMÁCIA ≡ FARMACIA.
- NEW HybridClassifier: rules-first → ML fallback. Low-confidence (or ML exception) uses amount sign as tie-breaker: credit (positive) → INCOME, debit (negative) → MISCELLANEOUS. Prevents credits from landing in an EXPENSE-type category and making expense totals negative.
- FIX WekaRandomForestClassifier.buildVocabulary: removed entry.getValue() > 1 filter so single-occurrence merchant names contribute features.
- FIX FeatureExtractor.tokens: NFD accent stripping so FARMÁCIA and FARMACIA share a token.
- FIX GuestImport.resolveCategoryTypes: now adds parent categories (INCOME, HOUSING, …) to the lookup map alongside subcategories so classifier outputs like "INCOME" resolve to the correct CategoryType instead of defaulting to EXPENSE.
- WIRE di/DI: produceClassifier now returns HybridClassifier(ClassificationRules, weka).

## Tests
- ClassificationRulesTest: normalise, known merchant, accented merchant, EXCLUDED-via-rule-only, unknown→empty, rule ordering (13 tests, no mocks).
- HybridClassifierTest: rule wins, high-confidence ML forwarded, low-confidence debit→MISC, low-confidence credit→INCOME, ML exception fallback, EXCLUDED override, batch (11 tests, no mocks).
- FeatureExtractorTest: new accent-stripping case.
- GuestImportTest: parentCategoryNameResolvesCorrectly, unrecognisedCreditDoesNotCorruptExpenseTotal.

## Root cause of negative percentages (descarga.xls) Without amount-sign fallback, unrecognised credits (salary, tax refunds) landed in MISCELLANEOUS (EXPENSE type). SummaryEngine negates EXPENSE amounts → positive credit became negative expense contribution → expense total negative → all shares negative. Also: GuestImport lookup missing parent category entries caused "INCOME" to default to CategoryType.EXPENSE, zeroing income.

## Notes / next iteration
- SAVINGS & INVESTMENTS is CategoryType.INCOME; large savings deposits (negative debits) reduce sumByType(INCOME), which can still make income negative in months with big lump-sum transfers. Tracked as a domain-model question (possible EXCLUDED reclassification) in issue 0016 notes.
- Santander Categoria column wiring still pending (out of scope for this tracer bullet).